### PR TITLE
feat: update to parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "ordered-float",
  "path-absolutize",
  "serde",
- "source-map",
+ "source-map 0.12.0",
  "temporary-annex",
 ]
 
@@ -196,7 +196,7 @@ dependencies = [
  "match_deref",
  "pretty_assertions",
  "self-rust-tokenize",
- "source-map",
+ "source-map 0.13.0",
  "temporary-annex",
  "tokenizer-lib",
 ]
@@ -800,6 +800,15 @@ name = "source-map"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedd4de16a29859eebdc14368c1fc2f5227ba58e1fdaba748072bf80ed9c5a35"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "source-map"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebacbfb6ea7b5257c72f8d2f7790cf4fc3e72f399d76b56d48f6290c8ed7789"
 dependencies = [
  "codespan-reporting",
  "self-rust-tokenize",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -23,7 +23,7 @@ temporary-annex = "0.1.0"
 iterator-endiate = "0.1.0"
 enum_variant_type = "0.3.1"
 enum-variants-strings = "0.2"
-source-map = { version = "0.12", features = [
+source-map = { version = "0.13", features = [
   "span-serialize",
   "self-rust-tokenize",
 ] }

--- a/parser/examples/chain.rs
+++ b/parser/examples/chain.rs
@@ -18,7 +18,7 @@ struct ShowChain;
 
 impl Visitor<Expression, ()> for ShowChain {
     fn visit(&mut self, item: &Expression, _data: &mut (), chain: &Chain) {
-        if matches!(item, Expression::VariableReference(name, _, _) if name == "chain") {
+        if matches!(item, Expression::VariableReference(name, _) if name == "chain") {
             eprintln!("{:#?}", chain);
         }
     }

--- a/parser/examples/jsx.rs
+++ b/parser/examples/jsx.rs
@@ -1,4 +1,4 @@
-use decaf_parser::{ASTNode, JSXRoot, SourceId, ToStringSettings};
+use decaf_parser::{ASTNode, JSXRoot, SourceId, ToStringOptions};
 
 fn main() {
     let source = "<MySiteLayout> <p>My page content, wrapped in a layout!</p> </MySiteLayout>";
@@ -11,5 +11,5 @@ fn main() {
     )
     .unwrap();
 
-    println!("{}", result.to_string(&ToStringSettings::default()));
+    println!("{}", result.to_string(&ToStringOptions::default()));
 }

--- a/parser/examples/lex.rs
+++ b/parser/examples/lex.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::{ParallelTokenQueue, TokenReader};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::args().skip(1).next().ok_or("expected argument")?;
     let content = std::fs::read_to_string(path)?;
-    lex_and_print_tokens(content, Some(vec![(31, EmptyCursorId::new(0))]));
+    lex_and_print_tokens(content, None);
     Ok(())
 }
 

--- a/parser/examples/parse.rs
+++ b/parser/examples/parse.rs
@@ -1,15 +1,20 @@
-use decaf_parser::{ASTNode, FromFileError, Module, ParseSettings, ToStringSettings};
+use std::time::Instant;
+
+use decaf_parser::{ASTNode, FromFileError, Module, ParseOptions, ToStringOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::args().skip(1).next().ok_or("expected argument")?;
+    let now = Instant::now();
     let mut fs = source_map::MapFileStore::default();
-    match Module::from_file(&path, ParseSettings::default(), Vec::default(), &mut fs) {
+    match Module::from_file(&path, ParseOptions::default(), Vec::default(), &mut fs) {
         Ok(module) => {
-            println!("{module:#?}");
-
-            let output = module.to_string(&ToStringSettings::default());
-            println!("In string form:");
-            println!("{output}");
+            println!("{:?}", now.elapsed());
+            if std::env::args().any(|item| item == "--ast") {
+                println!("{module:#?}");
+            } else {
+                let output = module.to_string(&ToStringOptions::default());
+                println!("{output}");
+            }
             Ok(())
         }
         Err(FromFileError::FileError(_file_err)) => {
@@ -20,7 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("parse error {}", parse_err.reason);
             println!(
                 "error on {:?}",
-                parse_err.position.into_line_column_span(&fs)
+                parse_err
+                    .position
+                    .into_line_column_span::<source_map::encodings::Utf8>(&fs)
             );
             Err(Box::<dyn std::error::Error>::from("error"))
         }

--- a/parser/examples/type_references.rs
+++ b/parser/examples/type_references.rs
@@ -1,7 +1,7 @@
-use decaf_parser::{ASTNode, Expression, SourceId, TypeReference};
+use decaf_parser::{ASTNode, Expression, SourceId, TypeAnnotation};
 
 fn main() {
-    let reference = TypeReference::from_string(
+    let reference = TypeAnnotation::from_string(
         "Pair<Nested<Object<2>>, Array<number>>".into(),
         Default::default(),
         SourceId::NULL,

--- a/parser/fuzz/Cargo.lock
+++ b/parser/fuzz/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedd4de16a29859eebdc14368c1fc2f5227ba58e1fdaba748072bf80ed9c5a35"
+checksum = "aebacbfb6ea7b5257c72f8d2f7790cf4fc3e72f399d76b56d48f6290c8ed7789"
 dependencies = [
  "codespan-reporting",
  "self-rust-tokenize",

--- a/parser/fuzz/fuzz_targets/module_roundtrip_naive.rs
+++ b/parser/fuzz/fuzz_targets/module_roundtrip_naive.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use decaf_parser::{ASTNode, Module, SourceId, ToStringSettings};
+use decaf_parser::{ASTNode, Module, SourceId, ToStringOptions};
 use libfuzzer_sys::{fuzz_target, Corpus};
 use pretty_assertions::assert_eq;
 use std::str;
@@ -21,7 +21,7 @@ fn do_fuzz(data: &str) -> Corpus {
         return Corpus::Reject;
     };
 
-    let output1 = module.to_string(&ToStringSettings::default());
+    let output1 = module.to_string(&ToStringOptions::default());
 
     let Ok(module) = Module::from_string(
         output1.to_owned(),
@@ -33,7 +33,7 @@ fn do_fuzz(data: &str) -> Corpus {
         panic!("input: `{input}`\noutput1: `{output1}`\n\nThis parse should not error because it was just parsed above");
     };
 
-    let output2 = module.to_string(&ToStringSettings::default());
+    let output2 = module.to_string(&ToStringOptions::default());
 
     assert_eq!(output1, output2);
 

--- a/parser/fuzz/fuzz_targets/module_roundtrip_structured.rs
+++ b/parser/fuzz/fuzz_targets/module_roundtrip_structured.rs
@@ -4,7 +4,7 @@ mod common {
     include!(concat!(env!("OUT_DIR"), "/common.rs")); // from build.rs
 }
 
-use decaf_parser::{ASTNode, Module, SourceId, ToStringSettings};
+use decaf_parser::{ASTNode, Module, SourceId, ToStringOptions};
 use libfuzzer_sys::{fuzz_target, Corpus};
 use pretty_assertions::assert_eq;
 
@@ -23,7 +23,7 @@ fn do_fuzz(data: common::FuzzSource) -> Corpus {
         return Corpus::Reject;
     };
 
-    let output1 = module.to_string(&ToStringSettings::default());
+    let output1 = module.to_string(&ToStringOptions::default());
 
     let Ok(module) = Module::from_string(
         output1.to_owned(),
@@ -35,7 +35,7 @@ fn do_fuzz(data: common::FuzzSource) -> Corpus {
         panic!("input: `{input}`\noutput1: `{output1}`\n\nThis parse should not error because it was just parsed above");
     };
 
-    let output2 = module.to_string(&ToStringSettings::default());
+    let output2 = module.to_string(&ToStringOptions::default());
 
     assert_eq!(output1, output2);
 

--- a/parser/generator/generator.rs
+++ b/parser/generator/generator.rs
@@ -50,7 +50,7 @@ fn token_stream_to_ast_node<T: parser::ASTNode + self_rust_tokenize::SelfRustTok
 
     let parse_result = T::from_string(
         string,
-        parser::ParseSettings::default(),
+        parser::ParseOptions::default(),
         parser::SourceId::NULL,
         None,
         cursors,

--- a/parser/src/block.rs
+++ b/parser/src/block.rs
@@ -1,9 +1,5 @@
-use std::{
-    borrow::Cow,
-    sync::atomic::{AtomicU16, Ordering},
-};
+use std::borrow::Cow;
 
-use derive_debug_extras::DebugExtras;
 use derive_enum_from_into::EnumFrom;
 use iterator_endiate::EndiateIteratorExt;
 use tokenizer_lib::Token;
@@ -11,36 +7,8 @@ use visitable_derive::Visitable;
 
 use super::{ASTNode, Span, TSXToken, TokenReader};
 use crate::{
-    expect_semi_colon, Declaration, ParseResult, ParseSettings, Statement, VisitSettings, Visitable,
+    expect_semi_colon, Declaration, ParseOptions, ParseResult, Statement, VisitSettings, Visitable,
 };
-
-static BLOCK_ID_COUNTER: AtomicU16 = AtomicU16::new(0);
-
-/// A identifier for a group of statements
-#[derive(PartialEq, Eq, Clone, Copy, DebugExtras, Hash)]
-pub struct BlockId(u16);
-
-// TODO not sure
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for BlockId {
-    fn append_to_token_stream(
-        &self,
-        token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-    ) {
-        token_stream.extend(self_rust_tokenize::quote!(BlockId::new()))
-    }
-}
-
-impl BlockId {
-    pub fn new() -> Self {
-        Self(BLOCK_ID_COUNTER.fetch_add(1, Ordering::SeqCst))
-    }
-
-    /// TODO temp
-    pub fn unwrap_counter(&self) -> u16 {
-        self.0
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Visitable)]
 #[cfg_attr(
@@ -75,7 +43,7 @@ impl ASTNode for StatementOrDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         if Declaration::is_declaration_start(reader) {
             let dec = Declaration::from_reader(reader, state, settings)?;
@@ -90,7 +58,7 @@ impl ASTNode for StatementOrDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -110,7 +78,7 @@ impl ASTNode for StatementOrDeclaration {
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub struct Block(pub Vec<StatementOrDeclaration>, pub BlockId, pub Span);
+pub struct Block(pub Vec<StatementOrDeclaration>, pub Span);
 
 impl Eq for Block {}
 
@@ -121,28 +89,22 @@ impl PartialEq for Block {
 }
 
 pub struct BlockLike<'a> {
-    pub block_id: BlockId,
     pub items: &'a Vec<StatementOrDeclaration>,
 }
 
 pub struct BlockLikeMut<'a> {
-    pub block_id: BlockId,
     pub items: &'a mut Vec<StatementOrDeclaration>,
 }
 
 impl<'a> From<&'a Block> for BlockLike<'a> {
     fn from(block: &'a Block) -> Self {
-        BlockLike {
-            block_id: block.1,
-            items: &block.0,
-        }
+        BlockLike { items: &block.0 }
     }
 }
 
 impl<'a> From<&'a mut Block> for BlockLikeMut<'a> {
     fn from(block: &'a mut Block) -> Self {
         BlockLikeMut {
-            block_id: block.1,
             items: &mut block.0,
         }
     }
@@ -152,18 +114,18 @@ impl ASTNode for Block {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start_span = reader.expect_next(TSXToken::OpenBrace)?;
-        let (items, block_id) = parse_statements_and_declarations(reader, state, settings)?;
+        let items = parse_statements_and_declarations(reader, state, settings)?;
         let end_span = reader.expect_next(TSXToken::CloseBrace)?;
-        Ok(Self(items, block_id, start_span.union(&end_span)))
+        Ok(Self(items, start_span.union(&end_span)))
     }
 
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push('{');
@@ -181,7 +143,7 @@ impl ASTNode for Block {
     }
 
     fn get_position(&self) -> Cow<Span> {
-        Cow::Borrowed(&self.2)
+        Cow::Borrowed(&self.1)
     }
 }
 
@@ -205,14 +167,7 @@ impl Visitable for Block {
         chain: &mut temporary_annex::Annex<crate::visiting::Chain>,
     ) {
         {
-            visitors.visit_block(
-                &crate::block::BlockLike {
-                    block_id: self.1,
-                    items: &self.0,
-                },
-                data,
-                chain,
-            );
+            visitors.visit_block(&crate::block::BlockLike { items: &self.0 }, data, chain);
         }
         let iter = self.iter();
         if settings.reverse_statements {
@@ -233,10 +188,7 @@ impl Visitable for Block {
     ) {
         {
             visitors.visit_block_mut(
-                &mut crate::block::BlockLikeMut {
-                    block_id: self.1,
-                    items: &mut self.0,
-                },
+                &mut crate::block::BlockLikeMut { items: &mut self.0 },
                 data,
                 chain,
             );
@@ -280,18 +232,24 @@ impl ASTNode for BlockOrSingleStatement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
-        Statement::from_reader(reader, state, settings).map(|stmt| match stmt {
+        let stmt = Statement::from_reader(reader, state, settings)?;
+        Ok(match stmt {
             Statement::Block(blk) => Self::Braced(blk),
-            stmt => Box::new(stmt).into(),
+            stmt => {
+                if stmt.requires_semi_colon() {
+                    expect_semi_colon(reader, &state.line_starts, stmt.get_position().start)?;
+                }
+                Box::new(stmt).into()
+            }
         })
     }
 
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -304,9 +262,7 @@ impl ASTNode for BlockOrSingleStatement {
                     settings.add_gap(buf);
                     stmt.to_string_from_buffer(buf, settings, depth);
                 } else {
-                    buf.push('{');
                     stmt.to_string_from_buffer(buf, settings, depth);
-                    buf.push('}');
                 }
             }
         }
@@ -317,10 +273,9 @@ impl ASTNode for BlockOrSingleStatement {
 pub(crate) fn parse_statements_and_declarations(
     reader: &mut impl TokenReader<TSXToken, Span>,
     state: &mut crate::ParsingState,
-    settings: &ParseSettings,
-) -> ParseResult<(Vec<StatementOrDeclaration>, BlockId)> {
+    settings: &ParseOptions,
+) -> ParseResult<Vec<StatementOrDeclaration>> {
     let mut items = Vec::new();
-    let block_id = BlockId::new();
     while let Some(Token(token_type, _)) = reader.peek() {
         if let TSXToken::EOS | TSXToken::CloseBrace = token_type {
             break;
@@ -328,17 +283,17 @@ pub(crate) fn parse_statements_and_declarations(
 
         let value = StatementOrDeclaration::from_reader(reader, state, settings)?;
         if value.requires_semi_colon() {
-            expect_semi_colon(reader)?;
+            expect_semi_colon(reader, &state.line_starts, value.get_position().end)?;
         }
         items.push(value);
     }
-    Ok((items, block_id))
+    Ok(items)
 }
 
 pub fn statements_and_declarations_to_string<T: source_map::ToString>(
     items: &[StatementOrDeclaration],
     buf: &mut T,
-    settings: &crate::ToStringSettings,
+    settings: &crate::ToStringOptions,
     depth: u8,
 ) {
     for (at_end, item) in items.iter().endiate() {

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -1,7 +1,7 @@
 //! Contains wrappers for AST with comments
 
 use super::{ASTNode, ParseError, Span, TSXToken, TokenReader};
-use crate::ParseSettings;
+use crate::ParseOptions;
 use std::{borrow::Cow, mem};
 use tokenizer_lib::Token;
 
@@ -102,7 +102,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> Result<WithComment<T>, ParseError> {
         if matches!(
             reader.peek(),
@@ -148,7 +148,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
     fn to_string_from_buffer<U: source_map::ToString>(
         &self,
         buf: &mut U,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {

--- a/parser/src/declarations/classes/mod.rs
+++ b/parser/src/declarations/classes/mod.rs
@@ -8,8 +8,8 @@ use iterator_endiate::EndiateIteratorExt;
 
 use crate::{
     extensions::decorators::Decorated, visiting::Visitable, ASTNode, ExpressionOrStatementPosition,
-    GenericTypeConstraint, Keyword, ParseResult, ParseSettings, Span, TSXKeyword, TSXToken, TypeId,
-    TypeReference, VariableId, VisitSettings,
+    GenericTypeConstraint, Keyword, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken,
+    TypeAnnotation, VisitSettings,
 };
 use tokenizer_lib::{Token, TokenReader};
 
@@ -19,12 +19,8 @@ pub struct ClassDeclaration<T: ExpressionOrStatementPosition> {
     pub name: T::Name,
     pub type_parameters: Option<Vec<GenericTypeConstraint>>,
     /// TODO shouldn't be type reference
-    pub extends: Option<TypeReference>,
+    pub extends: Option<TypeAnnotation>,
     pub members: Vec<Decorated<ClassMember>>,
-    /// The [TypeId] is the type of the instance the class defines
-    pub type_id: TypeId,
-    /// The [VariableId] is for `SomeClass.constructor` and possible static properties etc
-    pub variable_id: VariableId,
     pub position: Span,
 }
 
@@ -46,7 +42,7 @@ impl<U: ExpressionOrStatementPosition + Debug + PartialEq + Eq + Clone + 'static
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let class_keyword_pos = reader.expect_next(TSXToken::Keyword(TSXKeyword::Class))?;
         let class_keyword = Keyword::new(class_keyword_pos);
@@ -56,7 +52,7 @@ impl<U: ExpressionOrStatementPosition + Debug + PartialEq + Eq + Clone + 'static
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         self.to_string_from_buffer(buf, settings, depth)
@@ -71,14 +67,23 @@ impl<U: ExpressionOrStatementPosition> ClassDeclaration<U> {
     pub(crate) fn from_reader_sub_class_keyword(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         class_keyword: Keyword<tsx_keywords::Class>,
     ) -> ParseResult<Self> {
-        let (name, type_parameters) = U::from_reader(reader, state, settings)?;
+        let name = U::from_reader(reader, state, settings)?;
+        let type_parameters = reader
+            .conditional_next(|token| *token == TSXToken::OpenChevron)
+            .is_some()
+            .then(|| {
+                crate::parse_bracketed(reader, state, settings, None, TSXToken::CloseChevron)
+                    .map(|(params, _)| params)
+            })
+            .transpose()?;
+
         let extends = match reader.peek() {
             Some(Token(TSXToken::Keyword(TSXKeyword::Extends), _)) => {
                 reader.next();
-                Some(TypeReference::from_reader(reader, state, settings)?)
+                Some(TypeAnnotation::from_reader(reader, state, settings)?)
             }
             _ => None,
         };
@@ -101,8 +106,6 @@ impl<U: ExpressionOrStatementPosition> ClassDeclaration<U> {
         Ok(ClassDeclaration {
             class_keyword,
             name,
-            type_id: TypeId::new(),
-            variable_id: VariableId::new(),
             extends,
             members,
             type_parameters,
@@ -113,7 +116,7 @@ impl<U: ExpressionOrStatementPosition> ClassDeclaration<U> {
     pub(crate) fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("class ");
@@ -141,10 +144,6 @@ impl<U: ExpressionOrStatementPosition> ClassDeclaration<U> {
             buf.push_new_line();
         }
         buf.push('}');
-    }
-
-    pub fn get_variable_id(&self) -> VariableId {
-        self.variable_id
     }
 }
 

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-    errors::parse_lexing_error, ASTNode, Expression, Keyword, ParseResult, ParseSettings, Span,
+    errors::parse_lexing_error, ASTNode, Expression, Keyword, ParseOptions, ParseResult, Span,
     StatementPosition, TSXKeyword, TSXToken, Token,
 };
 
@@ -57,7 +57,7 @@ impl ASTNode for ExportDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start = reader.expect_next(TSXToken::Keyword(TSXKeyword::Export))?;
         let is_default = matches!(
@@ -134,7 +134,7 @@ impl ASTNode for ExportDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -70,6 +70,7 @@ impl Declaration {
                         | TSXKeyword::Declare
                         | TSXKeyword::Import
                         | TSXKeyword::Export
+                        | TSXKeyword::Interface
                         | TSXKeyword::Async
                         | TSXKeyword::Generator
                 ) | TSXToken::At,
@@ -99,7 +100,7 @@ impl crate::ASTNode for Declaration {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, source_map::Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> crate::ParseResult<Self> {
         // TODO assert decorators are used. If they exist but item is not `Decorated`
         // then need to throw a parse error
@@ -222,7 +223,7 @@ impl crate::ASTNode for Declaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -4,7 +4,7 @@ use iterator_endiate::EndiateIteratorExt;
 
 use crate::{
     errors::parse_lexing_error, tsx_keywords, ASTNode, Expression, Keyword, ParseError,
-    ParseResult, ParseSettings, Span, TSXKeyword, TSXToken, Token, TokenReader, TypeReference,
+    ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, Token, TokenReader, TypeAnnotation,
     VariableField, VariableFieldInSourceCode, WithComment,
 };
 use visitable_derive::Visitable;
@@ -16,26 +16,28 @@ pub trait DeclarationExpression:
     fn decl_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self>;
 
     fn decl_to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     );
 
     fn get_decl_position(&self) -> Option<Cow<Span>>;
 
-    fn as_option_mut_expr(&mut self) -> Option<&mut Expression>;
+    fn as_option_expr_ref(&self) -> Option<&Expression>;
+
+    fn as_option_expr_mut(&mut self) -> Option<&mut Expression>;
 }
 
 impl DeclarationExpression for Option<Expression> {
     fn decl_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         if let Some(Token(TSXToken::Assign, _)) = reader.peek() {
             reader.next();
@@ -49,7 +51,7 @@ impl DeclarationExpression for Option<Expression> {
     fn decl_to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if let Some(expr) = self {
@@ -62,7 +64,11 @@ impl DeclarationExpression for Option<Expression> {
         self.as_ref().map(|expr| expr.get_position())
     }
 
-    fn as_option_mut_expr(&mut self) -> Option<&mut Expression> {
+    fn as_option_expr_ref(&self) -> Option<&Expression> {
+        self.as_ref()
+    }
+
+    fn as_option_expr_mut(&mut self) -> Option<&mut Expression> {
         self.as_mut()
     }
 }
@@ -71,7 +77,7 @@ impl DeclarationExpression for crate::Expression {
     fn decl_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         reader.expect_next(TSXToken::Assign)?;
         Expression::from_reader(reader, state, settings)
@@ -80,7 +86,7 @@ impl DeclarationExpression for crate::Expression {
     fn decl_to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str(if settings.pretty { " = " } else { "=" });
@@ -91,7 +97,11 @@ impl DeclarationExpression for crate::Expression {
         Some(ASTNode::get_position(self))
     }
 
-    fn as_option_mut_expr(&mut self) -> Option<&mut Expression> {
+    fn as_option_expr_ref(&self) -> Option<&Expression> {
+        Some(self)
+    }
+
+    fn as_option_expr_mut(&mut self) -> Option<&mut Expression> {
         Some(self)
     }
 }
@@ -104,7 +114,7 @@ impl DeclarationExpression for crate::Expression {
 )]
 pub struct VariableDeclarationItem<TExpr: DeclarationExpression> {
     pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
-    pub type_reference: Option<TypeReference>,
+    pub type_annotation: Option<TypeAnnotation>,
     pub expression: TExpr,
 }
 
@@ -113,7 +123,7 @@ impl<TExpr: DeclarationExpression + 'static> ASTNode for VariableDeclarationItem
         let name_position = self.name.get_position();
         if let Some(expr_pos) = TExpr::get_decl_position(&self.expression) {
             Cow::Owned(name_position.union(&expr_pos))
-        } else if let Some(ref ty_ref) = self.type_reference {
+        } else if let Some(ref ty_ref) = self.type_annotation {
             Cow::Owned(name_position.union(&ty_ref.get_position()))
         } else {
             name_position
@@ -123,22 +133,22 @@ impl<TExpr: DeclarationExpression + 'static> ASTNode for VariableDeclarationItem
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let name = WithComment::<VariableField<VariableFieldInSourceCode>>::from_reader(
             reader, state, settings,
         )?;
-        let type_reference = if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
+        let type_annotation = if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
             reader.next();
-            let type_reference = TypeReference::from_reader(reader, state, settings)?;
-            Some(type_reference)
+            let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+            Some(type_annotation)
         } else {
             None
         };
         let expression = TExpr::decl_from_reader(reader, state, settings)?;
         Ok(Self {
             name,
-            type_reference,
+            type_annotation,
             expression,
         })
     }
@@ -146,13 +156,13 @@ impl<TExpr: DeclarationExpression + 'static> ASTNode for VariableDeclarationItem
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         self.name.to_string_from_buffer(buf, settings, depth);
-        if let (true, Some(type_reference)) = (settings.include_types, &self.type_reference) {
+        if let (true, Some(type_annotation)) = (settings.include_types, &self.type_annotation) {
             buf.push_str(": ");
-            type_reference.to_string_from_buffer(buf, settings, depth);
+            type_annotation.to_string_from_buffer(buf, settings, depth);
         }
         self.expression
             .decl_to_string_from_buffer(buf, settings, depth);
@@ -230,7 +240,7 @@ impl ASTNode for VariableDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let kind =
             VariableDeclarationKeyword::from_reader(reader.next().ok_or_else(parse_lexing_error)?)?;
@@ -277,7 +287,7 @@ impl ASTNode for VariableDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -326,7 +336,7 @@ pub(crate) fn declarations_to_string<
 >(
     declarations: &[VariableDeclarationItem<U>],
     buf: &mut T,
-    settings: &crate::ToStringSettings,
+    settings: &crate::ToStringOptions,
     depth: u8,
 ) {
     for (at_end, declaration) in declarations.iter().endiate() {

--- a/parser/src/errors.rs
+++ b/parser/src/errors.rs
@@ -22,7 +22,6 @@ pub enum ParseErrors<'a> {
     TypeArgumentsNotValidOnReference,
     UnmatchedBrackets,
     FunctionParameterOptionalAndDefaultValue,
-    NonOptionalFunctionParameterAfterOptionalFunctionParameter,
     ExpectedIdent {
         found: TSXToken,
         at_location: &'a str,
@@ -133,9 +132,6 @@ impl<'a> Display for ParseErrors<'a> {
             ParseErrors::UnmatchedBrackets => f.write_str("Unmatched brackets"),
             ParseErrors::FunctionParameterOptionalAndDefaultValue => {
                 f.write_str("Function parameter cannot be optional *and* have default expression")
-            }
-            ParseErrors::NonOptionalFunctionParameterAfterOptionalFunctionParameter => {
-                f.write_str("Function parameter cannot be non optional after optional")
             }
             ParseErrors::ExpectedIdent { found, at_location } => {
                 write!(f, "Expected identifier at {at_location}, found {found:?}")

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -5,9 +5,9 @@ use visitable_derive::Visitable;
 
 use crate::{
     errors::parse_lexing_error, functions::FunctionBased, parameters::FunctionParameters,
-    tokens::token_as_identifier, ASTNode, Block, BlockId, ChainVariable, Expression, FunctionBase,
-    FunctionId, Keyword, Parameter, ParseResult, ParseSettings, Span, TSXKeyword, TSXToken, Token,
-    TokenReader, TypeReference, VariableField, VariableId, WithComment,
+    tokens::token_as_identifier, ASTNode, Block, Expression, FunctionBase, FunctionId, Keyword,
+    Parameter, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, Token, TokenReader,
+    TypeAnnotation, VariableField, WithComment,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -20,14 +20,14 @@ impl FunctionBased for ArrowFunctionBase {
     type Header = Option<Keyword<tsx_keywords::Async>>;
     type Name = ();
 
-    fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
-        ChainVariable::UnderArrowFunction(this.body.get_block_id())
-    }
+    // fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
+    // 	ChainVariable::UnderArrowFunction(this.body.get_block_id())
+    // }
 
     fn header_and_name_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         _state: &mut crate::ParsingState,
-        _settings: &ParseSettings,
+        _settings: &ParseOptions,
     ) -> ParseResult<(Self::Header, Self::Name)> {
         let is_async = if let Some(Token(TSXToken::Keyword(TSXKeyword::Async), _)) = reader.peek() {
             let Token(_, pos) = reader.next().unwrap();
@@ -42,7 +42,7 @@ impl FunctionBased for ArrowFunctionBase {
         buf: &mut T,
         is_async: &Self::Header,
         _name: &Self::Name,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
         if is_async.is_some() {
@@ -53,7 +53,7 @@ impl FunctionBased for ArrowFunctionBase {
     fn parameters_from_reader<T: source_map::ToString>(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<FunctionParameters> {
         match reader.next().ok_or_else(parse_lexing_error)? {
             Token(TSXToken::OpenParentheses, open_paren) => {
@@ -66,14 +66,13 @@ impl FunctionBased for ArrowFunctionBase {
                 let (name, position) = token_as_identifier(token, "arrow function parameter")?;
                 let parameters = vec![Parameter {
                     name: WithComment::None(
-                        VariableIdentifier::Standard(name, VariableId::new(), position.clone())
-                            .into(),
+                        VariableIdentifier::Standard(name, position.clone()).into(),
                     ),
-                    type_reference: None,
+                    type_annotation: None,
+                    additionally: None,
                 }];
                 Ok(FunctionParameters {
                     parameters,
-                    optional_parameters: Vec::new(),
                     rest_parameter: None,
                     position,
                 })
@@ -84,12 +83,12 @@ impl FunctionBased for ArrowFunctionBase {
     fn parameters_to_string_from_buffer<T: source_map::ToString>(
         buf: &mut T,
         parameters: &FunctionParameters,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         // Use shorthand if one parameter with no declared type
         if let (true, [Parameter { name, .. }]) = (
-            parameters.optional_parameters.is_empty() && parameters.rest_parameter.is_none(),
+            parameters.rest_parameter.is_none(),
             parameters.parameters.as_slice(),
         ) {
             if let VariableField::Name(name, ..) = name.get_ast() {
@@ -104,7 +103,7 @@ impl FunctionBased for ArrowFunctionBase {
 
     fn parameter_body_boundary_token_to_string_from_buffer<T: source_map::ToString>(
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
     ) {
         buf.push_str(if settings.pretty { " => " } else { "=>" });
     }
@@ -118,19 +117,15 @@ impl ArrowFunction {
     pub(crate) fn from_reader_with_first_parameter(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         first_parameter: (String, Span),
     ) -> ParseResult<Self> {
         let parameters = vec![crate::Parameter {
             name: WithComment::None(
-                VariableIdentifier::Standard(
-                    first_parameter.0,
-                    VariableId::new(),
-                    first_parameter.1.clone(),
-                )
-                .into(),
+                VariableIdentifier::Standard(first_parameter.0, first_parameter.1.clone()).into(),
             ),
-            type_reference: None,
+            type_annotation: None,
+            additionally: None,
         }];
         reader.expect_next(TSXToken::Arrow)?;
         let body = ExpressionOrBlock::from_reader(reader, state, settings)?;
@@ -139,7 +134,6 @@ impl ArrowFunction {
             name: (),
             parameters: crate::FunctionParameters {
                 parameters,
-                optional_parameters: Vec::new(),
                 rest_parameter: None,
                 position: first_parameter.1,
             },
@@ -154,7 +148,7 @@ impl ArrowFunction {
     pub(crate) fn from_reader_sub_open_paren(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         is_async: Option<Keyword<tsx_keywords::Async>>,
         open_paren_span: Span,
     ) -> ParseResult<Self> {
@@ -166,7 +160,7 @@ impl ArrowFunction {
         )?;
         let return_type = if matches!(reader.peek().unwrap().0, TSXToken::Colon) {
             reader.next();
-            Some(TypeReference::from_reader(reader, state, settings)?)
+            Some(TypeAnnotation::from_reader(reader, state, settings)?)
         } else {
             None
         };
@@ -192,15 +186,6 @@ pub enum ExpressionOrBlock {
     Block(Block),
 }
 
-impl ExpressionOrBlock {
-    pub fn get_block_id(&self) -> Option<BlockId> {
-        match self {
-            ExpressionOrBlock::Expression(_) => None,
-            ExpressionOrBlock::Block(block) => Some(block.1),
-        }
-    }
-}
-
 impl ASTNode for ExpressionOrBlock {
     fn get_position(&self) -> Cow<Span> {
         match self {
@@ -212,7 +197,7 @@ impl ASTNode for ExpressionOrBlock {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         if matches!(reader.peek().unwrap().0, TSXToken::OpenBrace) {
             Ok(Self::Block(Block::from_reader(reader, state, settings)?))
@@ -225,7 +210,7 @@ impl ASTNode for ExpressionOrBlock {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         FUNCTION_CALL_PRECEDENCE, OPTIONAL_CHAINING_PRECEDENCE,
     },
     parse_bracketed, to_string_bracketed,
-    type_references::generic_arguments_from_reader_sub_open_angle,
+    type_annotations::generic_arguments_from_reader_sub_open_angle,
     CursorId, ExpressionPosition, FunctionHeader, FunctionId, Keyword, NumberStructure,
     ParseResult, Quoted, TSXKeyword,
 };
@@ -26,12 +26,11 @@ use super::{
         PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE, TERNARY_PRECEDENCE,
     },
     tokens::token_as_identifier,
-    ASTNode, Block, FunctionBase, JSXRoot, ParseError, ParseSettings, Span, TSXToken, Token,
-    TokenReader, TypeReference,
+    ASTNode, Block, FunctionBase, JSXRoot, ParseError, ParseOptions, Span, TSXToken, Token,
+    TokenReader, TypeAnnotation,
 };
 
 use crate::tsx_keywords::{self, As, Generator, Is, Satisfies};
-use derive_debug_extras::DebugExtras;
 use derive_partial_eq_extras::PartialEqExtras;
 use visitable_derive::Visitable;
 
@@ -49,46 +48,13 @@ pub type ExpressionFunction = FunctionBase<ExpressionFunctionBase>;
 use std::{
     borrow::Cow,
     convert::{TryFrom, TryInto},
-    sync::atomic::{AtomicU16, Ordering},
 };
-
-static EXPRESSION_ID_COUNTER: AtomicU16 = AtomicU16::new(1);
-
-/// Id given to AST that declares a type
-/// Used for keeping track of expressions between passes
-#[derive(PartialEq, Eq, Clone, Copy, DebugExtras, Hash)]
-// #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-pub struct ExpressionId(u16);
-
-impl ExpressionId {
-    pub fn new() -> Self {
-        Self(EXPRESSION_ID_COUNTER.fetch_add(1, Ordering::SeqCst))
-    }
-
-    /// **Use with care**
-    pub const NULL: Self = Self(0);
-
-    /// TODO temp
-    pub fn unwrap_counter(&self) -> u16 {
-        self.0
-    }
-}
-
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for ExpressionId {
-    fn append_to_token_stream(
-        &self,
-        token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-    ) {
-        token_stream.extend(self_rust_tokenize::quote!(ExpressionId::NULL));
-    }
-}
 
 /// Expression structures
 ///
 /// Comma is implemented as a [BinaryOperator]
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
-#[partial_eq_ignore_types(Span, ExpressionId)]
+#[partial_eq_ignore_types(Span)]
 #[visit_self]
 #[cfg_attr(
     feature = "self-rust-tokenize",
@@ -96,74 +62,65 @@ impl self_rust_tokenize::SelfRustTokenize for ExpressionId {
 )]
 pub enum Expression {
     // Literals:
-    NumberLiteral(NumberStructure, Span, ExpressionId),
-    StringLiteral(String, #[partial_eq_ignore] Quoted, Span, ExpressionId),
-    BooleanLiteral(bool, Span, ExpressionId),
+    NumberLiteral(NumberStructure, Span),
+    StringLiteral(String, #[partial_eq_ignore] Quoted, Span),
+    BooleanLiteral(bool, Span),
     RegexLiteral {
         pattern: String,
         flags: Option<String>,
         position: Span,
-        id: ExpressionId,
     },
-    ArrayLiteral(Vec<SpreadExpression>, Span, ExpressionId),
+    ArrayLiteral(Vec<SpreadExpression>, Span),
     ObjectLiteral(ObjectLiteral),
     TemplateLiteral(TemplateLiteral),
-    ParenthesizedExpression(Box<MultipleExpression>, Span, ExpressionId),
+    ParenthesizedExpression(Box<MultipleExpression>, Span),
     // Regular operations:
     BinaryOperation {
         lhs: Box<Expression>,
         operator: BinaryOperator,
         rhs: Box<Expression>,
-        id: ExpressionId,
     },
-    SpecialOperators(SpecialOperators, Span, ExpressionId),
+    SpecialOperators(SpecialOperators, Span),
     UnaryOperation {
         operator: UnaryOperator,
         operand: Box<Expression>,
         position: Span,
-        id: ExpressionId,
     },
     // Assignment operations
     Assignment {
         lhs: LHSOfAssignment,
         rhs: Box<Expression>,
-        id: ExpressionId,
     },
     /// Modified assignment cannot have destructured thingies
     BinaryAssignmentOperation {
         lhs: VariableOrPropertyAccess,
         operator: BinaryAssignmentOperator,
         rhs: Box<Expression>,
-        id: ExpressionId,
     },
     UnaryPrefixAssignmentOperation {
         operator: UnaryPrefixAssignmentOperator,
         operand: VariableOrPropertyAccess,
         position: Span,
-        id: ExpressionId,
     },
     UnaryPostfixAssignmentOperation {
         operand: VariableOrPropertyAccess,
         operator: UnaryPostfixAssignmentOperator,
         position: Span,
-        id: ExpressionId,
     },
     /// e.g `x` or `(...).hi`
-    VariableReference(String, Span, ExpressionId),
-    ThisReference(Span, ExpressionId),
-    SuperExpression(SuperReference, Span, ExpressionId),
+    VariableReference(String, Span),
+    ThisReference(Span),
+    SuperExpression(SuperReference, Span),
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target
-    NewTarget(Span, ExpressionId),
+    NewTarget(Span),
     DynamicImport {
         path: Box<Expression>,
         position: Span,
-        expression_id: ExpressionId,
     },
     PropertyAccess {
         parent: Box<Expression>,
         property: PropertyReference,
         position: Span,
-        expression_id: ExpressionId,
         is_optional: bool,
     },
     /// e.g `...[4]`
@@ -171,39 +128,35 @@ pub enum Expression {
         indexee: Box<Expression>,
         indexer: Box<MultipleExpression>,
         position: Span,
-        expression_id: ExpressionId,
     },
     // Function calls
     FunctionCall {
         function: Box<Expression>,
-        type_arguments: Option<Vec<TypeReference>>,
+        type_arguments: Option<Vec<TypeAnnotation>>,
         arguments: Vec<SpreadExpression>,
         position: Span,
-        expression_id: ExpressionId,
     },
     ConstructorCall {
         constructor: Box<Expression>,
-        type_arguments: Option<Vec<TypeReference>>,
+        type_arguments: Option<Vec<TypeAnnotation>>,
         arguments: Option<Vec<SpreadExpression>>,
         position: Span,
-        expression_id: ExpressionId,
     },
     /// e.g `... ? ... ? ...`
     TernaryExpression {
         condition: Box<Expression>,
         truthy_result: Box<Expression>,
         falsy_result: Box<Expression>,
-        id: ExpressionId,
     },
     // Functions
     ArrowFunction(ArrowFunction),
     ExpressionFunction(ExpressionFunction),
     /// Yes classes can exist in expr position :?
-    ClassExpression(ClassDeclaration<ExpressionPosition>, ExpressionId),
-    Null(Span, ExpressionId),
+    ClassExpression(ClassDeclaration<ExpressionPosition>),
+    Null(Span),
     // Comments
-    PrefixComment(String, Box<Expression>, Span, ExpressionId),
-    PostfixComment(Box<Expression>, String, Span, ExpressionId),
+    PrefixComment(String, Box<Expression>, Span),
+    PostfixComment(Box<Expression>, String, Span),
     /// Allowed in trailing functions and JSX for some reason
     Comment(String, Span),
     /// TODO under cfg
@@ -217,7 +170,6 @@ pub enum Expression {
         #[visit_skip_field]
         cursor_id: CursorId<Expression>,
         position: Span,
-        expression_id: ExpressionId,
     },
 }
 
@@ -238,7 +190,7 @@ impl ASTNode for Expression {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Expression> {
         Self::from_reader_with_precedence(reader, state, settings, COMMA_PRECEDENCE)
     }
@@ -246,7 +198,7 @@ impl ASTNode for Expression {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         self.to_string_using_precedence(buf, settings, depth, COMMA_PRECEDENCE)
@@ -268,26 +220,26 @@ impl ASTNode for Expression {
             Self::BinaryAssignmentOperation { lhs, rhs, .. } => {
                 Cow::Owned(lhs.get_position().union(&rhs.get_position()))
             }
-            Self::NumberLiteral(_, pos, _)
-            | Self::StringLiteral(_, _, pos, _)
-            | Self::BooleanLiteral(_, pos, _)
-            | Self::ArrayLiteral(_, pos, _)
-            | Self::ParenthesizedExpression(_, pos, _)
-            | Self::SpecialOperators(_, pos, _)
+            Self::NumberLiteral(_, pos)
+            | Self::StringLiteral(_, _, pos)
+            | Self::BooleanLiteral(_, pos)
+            | Self::ArrayLiteral(_, pos)
+            | Self::ParenthesizedExpression(_, pos)
+            | Self::SpecialOperators(_, pos)
             | Self::UnaryOperation { position: pos, .. }
             | Self::UnaryPrefixAssignmentOperation { position: pos, .. }
             | Self::UnaryPostfixAssignmentOperation { position: pos, .. }
-            | Self::VariableReference(_, pos, _)
+            | Self::VariableReference(_, pos)
             | Self::Index { position: pos, .. }
-            | Self::Null(pos, _)
-            | Self::PrefixComment(_, _, pos, _)
-            | Self::PostfixComment(_, _, pos, _)
+            | Self::Null(pos)
+            | Self::PrefixComment(_, _, pos)
+            | Self::PostfixComment(_, _, pos)
             | Self::Comment(_, pos)
             | Self::FunctionCall { position: pos, .. }
             | Self::PropertyAccess { position: pos, .. }
-            | Self::ThisReference(pos, _)
-            | Self::NewTarget(pos, _)
-            | Self::SuperExpression(_, pos, _)
+            | Self::ThisReference(pos)
+            | Self::NewTarget(pos)
+            | Self::SuperExpression(_, pos)
             | Self::DynamicImport { position: pos, .. }
             | Self::ConstructorCall { position: pos, .. }
             | Self::RegexLiteral { position: pos, .. }
@@ -295,7 +247,7 @@ impl ASTNode for Expression {
             Self::JSXRoot(root) => root.get_position(),
             Self::ObjectLiteral(object_literal) => object_literal.get_position(),
             Self::TemplateLiteral(template_literal) => template_literal.get_position(),
-            Self::ClassExpression(class_expression, _) => class_expression.get_position(),
+            Self::ClassExpression(class_expression) => class_expression.get_position(),
             Self::IsExpression(is) => is.get_position(),
             Self::ArrowFunction(arrow_function) => arrow_function.get_position(),
             Self::ExpressionFunction(function) => function.get_position(),
@@ -307,7 +259,7 @@ impl Expression {
     pub(self) fn from_reader_with_precedence(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         return_precedence: u8,
     ) -> ParseResult<Self> {
         let first_expression = match reader.next().ok_or_else(parse_lexing_error)? {
@@ -315,20 +267,21 @@ impl Expression {
                 return Ok(Expression::Cursor {
                     cursor_id: cursor_id.into_cursor(),
                     position,
-                    expression_id: ExpressionId::new(),
                 });
             }
             Token(TSXToken::SingleQuotedStringLiteral(expression), position) => {
-                Expression::StringLiteral(expression, Quoted::Single, position, ExpressionId::new())
+                Expression::StringLiteral(expression, Quoted::Single, position)
             }
             Token(TSXToken::DoubleQuotedStringLiteral(expression), position) => {
-                Expression::StringLiteral(expression, Quoted::Double, position, ExpressionId::new())
+                Expression::StringLiteral(expression, Quoted::Double, position)
             }
-            Token(TSXToken::NumberLiteral(value), position) => Expression::NumberLiteral(
-                value.parse::<NumberStructure>().unwrap(),
-                position,
-                ExpressionId::new(),
-            ),
+            Token(TSXToken::NumberLiteral(value), position) => {
+                let res = value.parse::<NumberStructure>();
+                match res {
+                    Ok(number) => Expression::NumberLiteral(number, position),
+                    Err(_) => unreachable!("Could not parse {value}"),
+                }
+            }
             Token(TSXToken::RegexLiteral(pattern), mut position) => {
                 let flag_token =
                     reader.conditional_next(|t| matches!(t, TSXToken::RegexFlagLiteral(..)));
@@ -344,17 +297,16 @@ impl Expression {
                     pattern,
                     flags,
                     position,
-                    id: ExpressionId::new(),
                 }
             }
             Token(TSXToken::Keyword(TSXKeyword::True), position) => {
-                Expression::BooleanLiteral(true, position, ExpressionId::new())
+                Expression::BooleanLiteral(true, position)
             }
             Token(TSXToken::Keyword(TSXKeyword::False), position) => {
-                Expression::BooleanLiteral(false, position, ExpressionId::new())
+                Expression::BooleanLiteral(false, position)
             }
             Token(TSXToken::Keyword(TSXKeyword::This), position) => {
-                Expression::ThisReference(position, ExpressionId::new())
+                Expression::ThisReference(position)
             }
             Token(TSXToken::Keyword(TSXKeyword::Super), position) => {
                 let Token(token, modifier_pos) = reader.next().unwrap();
@@ -398,17 +350,15 @@ impl Expression {
                         ));
                     }
                 };
-                Expression::SuperExpression(reference, position.union(&end), ExpressionId::new())
+                Expression::SuperExpression(reference, position.union(&end))
             }
-            Token(TSXToken::Keyword(TSXKeyword::Null), position) => {
-                Expression::Null(position, ExpressionId::new())
-            }
+            Token(TSXToken::Keyword(TSXKeyword::Null), position) => Expression::Null(position),
             Token(TSXToken::Keyword(TSXKeyword::Class), position) => {
                 let keyword = Keyword(tsx_keywords::Class, position);
                 let class_declaration = ClassDeclaration::from_reader_sub_class_keyword(
                     reader, state, settings, keyword,
                 )?;
-                Expression::ClassExpression(class_declaration, ExpressionId::new())
+                Expression::ClassExpression(class_declaration)
             }
             Token(TSXToken::OpenBracket, start_pos) => {
                 let mut bracket_depth = 1;
@@ -438,19 +388,13 @@ impl Expression {
                             lhs: LHSOfAssignment::ArrayDestructuring(
                                 members,
                                 start_pos.union(&end_span),
-                                ExpressionId::new(),
                             ),
                             rhs: Box::new(rhs),
-                            id: ExpressionId::new(),
                         }
                     } else {
                         let (items, end_pos) =
                             parse_bracketed(reader, state, settings, None, TSXToken::CloseBracket)?;
-                        Expression::ArrayLiteral(
-                            items,
-                            start_pos.union(&end_pos),
-                            ExpressionId::new(),
-                        )
+                        Expression::ArrayLiteral(items, start_pos.union(&end_pos))
                     }
                 } else {
                     return Err(ParseError::new(
@@ -487,10 +431,8 @@ impl Expression {
                             lhs: LHSOfAssignment::ObjectDestructuring(
                                 members,
                                 start_pos.union(&end_span),
-                                ExpressionId::new(),
                             ),
                             rhs: Box::new(rhs),
-                            id: ExpressionId::new(),
                         }
                     } else {
                         let object_literal = ObjectLiteral::from_reader_sub_open_curly(
@@ -535,7 +477,6 @@ impl Expression {
                         Expression::ParenthesizedExpression(
                             Box::new(parenthesize_expression),
                             open_paren_span.union(&close_paren_span),
-                            ExpressionId::new(),
                         )
                     }
                 } else {
@@ -550,7 +491,7 @@ impl Expression {
                     // TODO assert not lonely, else syntax error
                     reader.expect_next(TSXToken::Dot)?;
                     reader.expect_next(TSXToken::IdentLiteral("target".into()))?;
-                    Expression::NewTarget(new_pos, ExpressionId::new())
+                    Expression::NewTarget(new_pos)
                 } else {
                     // Pass as a function call and then adds the conversion
                     let constructor_expression = Self::from_reader_with_precedence(
@@ -585,7 +526,6 @@ impl Expression {
                         type_arguments,
                         arguments,
                         position: new_pos.union(&end_pos),
-                        expression_id: ExpressionId::new(),
                     }
                 }
             }
@@ -605,12 +545,7 @@ impl Expression {
                 let expression =
                     Self::from_reader_with_precedence(reader, state, settings, return_precedence)?;
                 let position = start_pos.union(&expression.get_position());
-                Expression::PrefixComment(
-                    comment,
-                    Box::new(expression),
-                    position,
-                    ExpressionId::new(),
-                )
+                Expression::PrefixComment(comment, Box::new(expression), position)
             }
             Token(tok @ TSXToken::JSXOpeningTagStart | tok @ TSXToken::JSXFragmentStart, span) => {
                 let var_name = matches!(tok, TSXToken::JSXFragmentStart);
@@ -635,11 +570,7 @@ impl Expression {
                 } else {
                     let (token, span) =
                         token_as_identifier(reader.next().unwrap(), "function name")?;
-                    Some(crate::VariableIdentifier::Standard(
-                        token,
-                        crate::VariableId::new(),
-                        span,
-                    ))
+                    Some(crate::VariableIdentifier::Standard(token, span))
                 };
                 let function: ExpressionFunction = FunctionBase::from_reader_with_header_and_name(
                     reader, state, settings, header, name,
@@ -685,11 +616,7 @@ impl Expression {
                         } else {
                             let (token, span) =
                                 token_as_identifier(reader.next().unwrap(), "function name")?;
-                            Some(crate::VariableIdentifier::Standard(
-                                token,
-                                crate::VariableId::new(),
-                                span,
-                            ))
+                            Some(crate::VariableIdentifier::Standard(token, span))
                         };
                         let function: ExpressionFunction =
                             FunctionBase::from_reader_with_header_and_name(
@@ -724,13 +651,14 @@ impl Expression {
             }
             #[cfg(feature = "extras")]
             Token(TSXToken::Keyword(TSXKeyword::Is), span) => {
-                is_expression_from_reader_sub_is_keyword(
-                    reader,
-                    state,
-                    settings,
-                    Keyword::new(span),
-                )
-                .map(Expression::IsExpression)?
+                let is_expression_from_reader_sub_is_keyword =
+                    is_expression_from_reader_sub_is_keyword(
+                        reader,
+                        state,
+                        settings,
+                        Keyword::new(span),
+                    );
+                is_expression_from_reader_sub_is_keyword.map(Expression::IsExpression)?
             }
             token => {
                 if let Ok(unary_operator) = UnaryOperator::try_from(&token.0) {
@@ -742,20 +670,23 @@ impl Expression {
                         operand: Box::new(operand),
                         operator: unary_operator,
                         position,
-                        id: ExpressionId::new(),
                     }
                 } else if let Ok(unary_prefix_operator) =
                     UnaryPrefixAssignmentOperator::try_from(&token.0)
                 {
                     // TODO is precedence needed...?
-                    // let op_precedence = unary_prefix_operator.precedence();
-                    let operand = VariableOrPropertyAccess::from_reader(reader, state, settings)?;
+                    let op_precedence = unary_prefix_operator.precedence();
+                    let operand = VariableOrPropertyAccess::from_reader_with_precedence(
+                        reader,
+                        state,
+                        settings,
+                        op_precedence,
+                    )?;
                     let position = token.1.union(&operand.get_position());
                     Expression::UnaryPrefixAssignmentOperation {
                         operand,
                         operator: unary_prefix_operator,
                         position,
-                        id: ExpressionId::new(),
                     }
                 } else {
                     let (name, position) = token_as_identifier(token, "variable reference")?;
@@ -768,7 +699,7 @@ impl Expression {
                         )?;
                         Expression::ArrowFunction(function)
                     } else {
-                        Expression::VariableReference(name, position, ExpressionId::new())
+                        Expression::VariableReference(name, position)
                     }
                 }
             }
@@ -785,7 +716,7 @@ impl Expression {
     pub(crate) fn from_reader_sub_first_expression(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         parent_precedence: u8,
         first_expression: Expression,
     ) -> ParseResult<Self> {
@@ -811,7 +742,6 @@ impl Expression {
                         condition: Box::new(top),
                         truthy_result: Box::new(lhs),
                         falsy_result: Box::new(rhs),
-                        id: ExpressionId::new(),
                     };
                 }
                 TSXToken::OpenParentheses => {
@@ -829,7 +759,6 @@ impl Expression {
                         type_arguments: None,
                         arguments,
                         position,
-                        expression_id: ExpressionId::new(),
                     };
                 }
                 TSXToken::OpenBracket => {
@@ -846,7 +775,6 @@ impl Expression {
                         position,
                         indexee: Box::new(top),
                         indexer: Box::new(indexer),
-                        expression_id: ExpressionId::new(),
                     };
                 }
                 TSXToken::TemplateLiteralStart => {
@@ -891,7 +819,6 @@ impl Expression {
                         parent: Box::new(top),
                         property,
                         position,
-                        expression_id: ExpressionId::new(),
                         is_optional,
                     };
                 }
@@ -911,7 +838,6 @@ impl Expression {
                     top = Expression::Assignment {
                         lhs: LHSOfAssignment::VariableOrPropertyAccess(top.try_into()?),
                         rhs: Box::new(new_rhs),
-                        id: ExpressionId::new(),
                     };
                 }
                 TSXToken::MultiLineComment(_) | TSXToken::Comment(_) => {
@@ -922,12 +848,7 @@ impl Expression {
                     else {
                         unreachable!()
                     };
-                    top = Expression::PostfixComment(
-                        Box::new(top),
-                        comment,
-                        position,
-                        ExpressionId::new(),
-                    );
+                    top = Expression::PostfixComment(Box::new(top), comment, position);
                 }
                 TSXToken::Keyword(TSXKeyword::As | TSXKeyword::Satisfies | TSXKeyword::Is) => {
                     if AssociativityDirection::LeftToRight
@@ -937,7 +858,7 @@ impl Expression {
                     }
 
                     let Token(token, keyword_pos) = reader.next().unwrap();
-                    let reference = TypeReference::from_reader(reader, state, settings)?;
+                    let reference = TypeAnnotation::from_reader(reader, state, settings)?;
                     let position = top.get_position().union(&reference.get_position());
 
                     let special_operators = match token {
@@ -960,7 +881,7 @@ impl Expression {
                         }
                         _ => unreachable!(),
                     };
-                    top = Self::SpecialOperators(special_operators, position, ExpressionId::new());
+                    top = Self::SpecialOperators(special_operators, position);
                 }
                 token => {
                     let token = if *token == TSXToken::OpenChevron {
@@ -981,7 +902,6 @@ impl Expression {
                                 function: Box::new(top),
                                 type_arguments: Some(type_arguments),
                                 arguments,
-                                expression_id: ExpressionId::new(),
                             };
                             continue;
                         } else {
@@ -1006,7 +926,6 @@ impl Expression {
                             operand: top.try_into()?,
                             operator,
                             position,
-                            id: ExpressionId::new(),
                         };
                     } else if let Ok(operator) = BinaryOperator::try_from(token) {
                         if operator
@@ -1028,7 +947,6 @@ impl Expression {
                             lhs: Box::new(top),
                             operator,
                             rhs: Box::new(rhs),
-                            id: ExpressionId::new(),
                         };
                     } else if let Ok(operator) = BinaryAssignmentOperator::try_from(token) {
                         if operator
@@ -1048,7 +966,6 @@ impl Expression {
                             lhs: top.try_into()?,
                             operator,
                             rhs: Box::new(new_rhs),
-                            id: ExpressionId::new(),
                         };
                     } else {
                         // debug_assert!(
@@ -1107,11 +1024,11 @@ impl Expression {
             }
             Self::Index { .. } => INDEX_PRECEDENCE,
             Self::TernaryExpression { .. } => TERNARY_PRECEDENCE,
-            Self::PrefixComment(_, expression, _, _) | Self::PostfixComment(expression, _, _, _) => {
+            Self::PrefixComment(_, expression, _) | Self::PostfixComment(expression, _, _) => {
                 expression.get_precedence()
             }
             Self::Comment(_, _) => PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE, // TODO not sure about this
-            Self::SpecialOperators(op, _, _) => match op {
+            Self::SpecialOperators(op, _) => match op {
 				 // TODO not sure about this
                 SpecialOperators::AsExpression { .. } => PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE,
                 SpecialOperators::IsExpression { .. } => PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE,
@@ -1123,7 +1040,7 @@ impl Expression {
     pub(crate) fn to_string_using_precedence<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
         _parent_precedence: u8,
     ) {
@@ -1133,13 +1050,13 @@ impl Expression {
                     panic!();
                 }
             }
-            Self::NumberLiteral(num, _, _) => buf.push_str(&num.to_string()),
-            Self::StringLiteral(string, quoted, _, _) => {
+            Self::NumberLiteral(num, _) => buf.push_str(&num.to_string()),
+            Self::StringLiteral(string, quoted, _) => {
                 buf.push(quoted.as_char());
                 buf.push_str(string);
                 buf.push(quoted.as_char());
             }
-            Self::BooleanLiteral(expression, _, _) => {
+            Self::BooleanLiteral(expression, _) => {
                 buf.push_str(if *expression { "true" } else { "false" });
             }
             Self::RegexLiteral { pattern, flags, .. } => {
@@ -1160,7 +1077,7 @@ impl Expression {
                 settings.add_gap(buf);
                 rhs.to_string_using_precedence(buf, settings, depth, op_precedence);
             }
-            Self::SpecialOperators(special, _, _) => match special {
+            Self::SpecialOperators(special, _) => match special {
                 SpecialOperators::AsExpression {
                     value,
                     type_annotation,
@@ -1220,7 +1137,7 @@ impl Expression {
                 operand.to_string_from_buffer(buf, settings, depth);
                 buf.push_str(operator.to_str());
             }
-            Self::VariableReference(name, _position, _) => {
+            Self::VariableReference(name, _position) => {
                 buf.push_str(name);
             }
             Self::ThisReference(..) => {
@@ -1252,7 +1169,7 @@ impl Expression {
                     panic!("found cursor");
                 }
             }
-            Self::ParenthesizedExpression(expr, _, _) => {
+            Self::ParenthesizedExpression(expr, _) => {
                 buf.push('(');
                 expr.to_string_from_buffer(buf, settings, depth);
                 buf.push(')');
@@ -1302,7 +1219,7 @@ impl Expression {
                     }
                 }
             }
-            Self::ArrayLiteral(values, _, _) => {
+            Self::ArrayLiteral(values, _) => {
                 to_string_bracketed(values, ('[', ']'), buf, settings, depth);
             }
             Self::JSXRoot(root) => root.to_string_from_buffer(buf, settings, depth),
@@ -1315,8 +1232,8 @@ impl Expression {
             Self::ExpressionFunction(function) => {
                 function.to_string_from_buffer(buf, settings, depth);
             }
-            Self::ClassExpression(class, _) => class.to_string_from_buffer(buf, settings, depth),
-            Self::PrefixComment(comment, expression, _, _) => {
+            Self::ClassExpression(class) => class.to_string_from_buffer(buf, settings, depth),
+            Self::PrefixComment(comment, expression, _) => {
                 if settings.should_add_comment() {
                     buf.push_str("/*");
                     buf.push_str_contains_new_line(comment.as_str());
@@ -1324,7 +1241,7 @@ impl Expression {
                 }
                 expression.to_string_from_buffer(buf, settings, depth);
             }
-            Self::PostfixComment(expression, comment, _, _) => {
+            Self::PostfixComment(expression, comment, _) => {
                 expression.to_string_from_buffer(buf, settings, depth);
                 if settings.should_add_comment() {
                     buf.push_str(" /*");
@@ -1356,7 +1273,7 @@ impl Expression {
             }
             Self::Null(..) => buf.push_str("null"),
             Self::IsExpression(is_expr) => is_expr.to_string_from_buffer(buf, settings, depth),
-            Self::SuperExpression(super_expr, _, _) => {
+            Self::SuperExpression(super_expr, _) => {
                 buf.push_str("super");
                 match super_expr {
                     SuperReference::Call { arguments } => {
@@ -1410,7 +1327,7 @@ impl ASTNode for MultipleExpression {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let first = Expression::from_reader(reader, state, settings)?;
         let mut top: MultipleExpression = first.into();
@@ -1428,12 +1345,12 @@ impl ASTNode for MultipleExpression {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if let Some(ref lhs) = self.lhs {
-            buf.push(',');
             lhs.to_string_from_buffer(buf, settings, depth);
+            buf.push(',');
         }
         self.rhs.to_string_from_buffer(buf, settings, depth);
     }
@@ -1499,7 +1416,7 @@ fn is_generic_arguments(reader: &mut impl TokenReader<TSXToken, Span>) -> bool {
 
 /// Binary operations whose RHS are types rather than [Expression]s
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
-#[partial_eq_ignore_types(Span, ExpressionId)]
+#[partial_eq_ignore_types(Span)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
@@ -1509,19 +1426,19 @@ pub enum SpecialOperators {
     AsExpression {
         value: Box<Expression>,
         as_keyword: Keyword<As>,
-        type_annotation: Box<TypeReference>,
+        type_annotation: Box<TypeAnnotation>,
     },
     /// TS Only
     SatisfiesExpression {
         value: Box<Expression>,
         satisfies_keyword: Keyword<Satisfies>,
-        type_annotation: Box<TypeReference>,
+        type_annotation: Box<TypeAnnotation>,
     },
     #[cfg(feature = "extras")]
     IsExpression {
         value: Box<Expression>,
         is_keyword: Keyword<Is>,
-        type_annotation: Box<TypeReference>,
+        type_annotation: Box<TypeAnnotation>,
     },
 }
 
@@ -1549,7 +1466,7 @@ impl ASTNode for SpreadExpression {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let peek = &reader.peek().ok_or_else(parse_lexing_error)?.0;
         match peek {
@@ -1571,7 +1488,7 @@ impl ASTNode for SpreadExpression {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -1588,16 +1505,6 @@ impl ASTNode for SpreadExpression {
 }
 
 impl SpreadExpression {
-    /// TODO Remover for get_inner_expression
-    pub fn get_expression_id(&self) -> Option<ExpressionId> {
-        match self {
-            SpreadExpression::Spread(expression, _) | SpreadExpression::NonSpread(expression) => {
-                expression.get_expression_id()
-            }
-            _ => panic!(),
-        }
-    }
-
     /// Only for walking
     fn _get_inner_expression_ref(&self) -> &Expression {
         match self {
@@ -1617,59 +1524,6 @@ impl From<Expression> for SpreadExpression {
 
 // Utils for Expression
 impl Expression {
-    pub fn get_expression_id(&self) -> Option<ExpressionId> {
-        match self {
-            Self::NumberLiteral(.., id)
-            | Self::StringLiteral(.., id)
-            | Self::BooleanLiteral(.., id)
-            | Self::RegexLiteral { id, .. }
-            | Self::ArrayLiteral(_, _, id)
-            | Self::ParenthesizedExpression(_, _, id)
-            | Self::BinaryOperation { id, .. }
-            | Self::Assignment { id, .. }
-            | Self::BinaryAssignmentOperation { id, .. }
-            | Self::UnaryOperation { id, .. }
-            | Self::UnaryPrefixAssignmentOperation { id, .. }
-            | Self::UnaryPostfixAssignmentOperation { id, .. }
-            | Self::VariableReference(_, _, id)
-            | Self::FunctionCall {
-                expression_id: id, ..
-            }
-            | Self::ConstructorCall {
-                expression_id: id, ..
-            }
-            | Self::Index {
-                expression_id: id, ..
-            }
-            | Self::TernaryExpression { id, .. }
-            | Self::Null(_, id)
-            | Self::SuperExpression(_, _, id)
-            | Self::ThisReference(_, id)
-            | Self::NewTarget(_, id)
-            | Self::TemplateLiteral(TemplateLiteral {
-                expression_id: id, ..
-            })
-            | Self::DynamicImport {
-                expression_id: id, ..
-            }
-            | Self::ClassExpression(_, id)
-            | Self::PrefixComment(_, _, _, id)
-            | Self::PostfixComment(_, _, _, id)
-            | Self::Cursor {
-                expression_id: id, ..
-            }
-            | Self::SpecialOperators(_, _, id)
-            | Self::PropertyAccess {
-                expression_id: id, ..
-            } => Some(*id),
-            Self::JSXRoot(root) => Some(root.get_expression_id()),
-            Self::ObjectLiteral(object_literal) => Some(object_literal.get_expression_id()),
-            Self::IsExpression(is_expr) => Some(is_expr.expression_id),
-            Self::Comment(..) => None,
-            Self::ExpressionFunction(..) | Self::ArrowFunction(..) => None,
-        }
-    }
-
     /// IIFE = immediate invoked function execution
     pub fn build_iife(block: Block) -> Self {
         let position = block.get_position().into_owned();
@@ -1682,7 +1536,6 @@ impl Expression {
                         name: (),
                         parameters: crate::FunctionParameters {
                             parameters: Default::default(),
-                            optional_parameters: Default::default(),
                             rest_parameter: Default::default(),
                             position: position.clone(),
                         },
@@ -1694,13 +1547,11 @@ impl Expression {
                     .into(),
                 ),
                 position.clone(),
-                ExpressionId::new(),
             )
             .into(),
             type_arguments: None,
             arguments: Vec::new(),
             position,
-            expression_id: ExpressionId::new(),
         }
     }
 
@@ -1711,7 +1562,7 @@ impl Expression {
             ..
         } = self
         {
-            if let (true, Expression::ParenthesizedExpression(expression, _, _)) =
+            if let (true, Expression::ParenthesizedExpression(expression, _)) =
                 (arguments.is_empty(), &**function)
             {
                 if let MultipleExpression {
@@ -1728,7 +1579,7 @@ impl Expression {
 
     /// Recurses to find first non parenthesized expression
     pub fn get_non_parenthesized(&self) -> &Self {
-        if let Expression::ParenthesizedExpression(inner_multiple_expr, _, _) = self {
+        if let Expression::ParenthesizedExpression(inner_multiple_expr, _) = self {
             if inner_multiple_expr.lhs.is_none() {
                 inner_multiple_expr.rhs.get_non_parenthesized()
             } else {
@@ -1760,7 +1611,7 @@ impl Expression {
 
 /// "super" cannot be used alone
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
-#[partial_eq_ignore_types(Span, ExpressionId)]
+#[partial_eq_ignore_types(Span)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
@@ -1782,16 +1633,16 @@ mod tests {
     fn literal() {
         assert_matches_ast!(
             "'string'",
-            StringLiteral(Deref @ "string", Quoted::Single, span!(0, 8), _)
+            StringLiteral(Deref @ "string", Quoted::Single, span!(0, 8))
         );
         assert_matches_ast!(
             "\"string\"",
-            StringLiteral(Deref @ "string", Quoted::Double, span!(0, 8), _)
+            StringLiteral(Deref @ "string", Quoted::Double, span!(0, 8))
         );
         // TODO different method
-        // assert_matches_ast!("45", NumberLiteral(NumberStructure::Number(45.0), span!(0, 2), _));
-        // assert_matches_ast!("45.63", NumberLiteral(NumberStructure::Number(45.63), span!(0, 5), _));
-        assert_matches_ast!("true", BooleanLiteral(true, span!(0, 4), _));
+        // assert_matches_ast!("45", NumberLiteral(NumberStructure::Number(45.0), span!(0, 2)));
+        // assert_matches_ast!("45.63", NumberLiteral(NumberStructure::Number(45.63), span!(0, 5)));
+        assert_matches_ast!("true", BooleanLiteral(true, span!(0, 4)));
     }
 
     #[test]
@@ -1801,10 +1652,9 @@ mod tests {
             ParenthesizedExpression(
                 Deref @ MultipleExpression {
                     lhs: None,
-                    rhs: NumberLiteral(NumberStructure::Number(_), span!(1, 3), _),
+                    rhs: NumberLiteral(NumberStructure::Number(_), span!(1, 3)),
                 },
                 span!(0, 4),
-                _,
             )
         );
     }
@@ -1832,13 +1682,12 @@ mod tests {
                         Some(
                             Deref @ MultipleExpression {
                                 lhs: None,
-                                rhs: NumberLiteral(NumberStructure::Number(_), span!(1, 3), _),
+                                rhs: NumberLiteral(NumberStructure::Number(_), span!(1, 3)),
                             },
                         ),
-                    rhs: NumberLiteral(NumberStructure::Number(_), span!(4, 5), _),
+                    rhs: NumberLiteral(NumberStructure::Number(_), span!(4, 5)),
                 },
                 span!(0, 6),
-                _,
             )
         );
     }
@@ -1846,34 +1695,29 @@ mod tests {
     #[test]
     fn binary_expressions() {
         assert_matches_ast!("2 + 3", BinaryOperation {
-            lhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(0, 1), _),
+            lhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(0, 1)),
             operator: BinaryOperator::Add,
-            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(4, 5), _),
-            id: _
+            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(4, 5)),
         });
         assert_matches_ast!("xt === 3", BinaryOperation {
             lhs: Deref @ VariableReference(..),
             operator: BinaryOperator::StrictEqual,
-            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(7, 8), _),
-            id: _
+            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(7, 8)),
         });
         assert_matches_ast!("x << 3", BinaryOperation {
             lhs: Deref @ VariableReference(..),
             operator: BinaryOperator::BitwiseShiftLeft,
-            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(5, 6), _),
-            id: _
+            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(5, 6)),
         });
         assert_matches_ast!("x >> 3", BinaryOperation {
             lhs: Deref @ VariableReference(..),
             operator: BinaryOperator::BitwiseShiftRight,
-            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(5, 6), _),
-            id: _
+            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(5, 6)),
         });
         assert_matches_ast!("x >>> 3", BinaryOperation {
             lhs: Deref @ VariableReference(..),
             operator: BinaryOperator::BitwiseShiftRightUnsigned,
-            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(6, 7), _),
-            id: _
+            rhs: Deref @ NumberLiteral(NumberStructure::Number(_), span!(6, 7)),
         });
     }
 }

--- a/parser/src/expressions/template_literal.rs
+++ b/parser/src/expressions/template_literal.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-    errors::parse_lexing_error, ASTNode, Expression, ParseResult, ParseSettings, Span, TSXToken,
+    errors::parse_lexing_error, ASTNode, Expression, ParseOptions, ParseResult, Span, TSXToken,
     Token, TokenReader,
 };
 use visitable_derive::Visitable;
@@ -15,7 +15,6 @@ pub struct TemplateLiteral {
     pub tag: Option<Box<Expression>>,
     pub parts: Vec<TemplateLiteralPart<Expression>>,
     pub position: Span,
-    pub expression_id: super::ExpressionId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,7 +80,7 @@ impl ASTNode for TemplateLiteral {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start_pos = reader.expect_next(TSXToken::TemplateLiteralStart)?;
         Self::from_reader_sub_start_with_tag(reader, state, settings, None, start_pos)
@@ -90,7 +89,7 @@ impl ASTNode for TemplateLiteral {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if let Some(tag) = &self.tag {
@@ -117,7 +116,7 @@ impl TemplateLiteral {
     pub(crate) fn from_reader_sub_start_with_tag(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         tag: Option<Box<Expression>>,
         start_position: Span,
     ) -> ParseResult<Self> {
@@ -137,7 +136,6 @@ impl TemplateLiteral {
                         parts,
                         tag,
                         position: start_position.union(&end_position),
-                        expression_id: super::ExpressionId::new(),
                     });
                 }
                 _ => unreachable!(),

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::{Token, TokenReader};
 use visitable_derive::Visitable;
 
 use crate::{
-    tokens::token_as_identifier, ASTNode, Expression, ParseResult, ParseSettings, TSXToken,
+    tokens::token_as_identifier, ASTNode, Expression, ParseOptions, ParseResult, TSXToken,
     Visitable,
 };
 
@@ -29,7 +29,7 @@ impl ASTNode for Decorator {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let at_pos = reader.expect_next(TSXToken::At)?;
         Self::from_reader_sub_at_symbol(reader, state, settings, at_pos)
@@ -38,7 +38,7 @@ impl ASTNode for Decorator {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_decorators {
@@ -63,7 +63,7 @@ impl Decorator {
     pub(crate) fn from_reader_sub_at_symbol(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         at_pos: Span,
     ) -> ParseResult<Self> {
         let (name, name_position) = token_as_identifier(reader.next().unwrap(), "Decorator name")?;
@@ -116,7 +116,7 @@ impl<N: ASTNode> ASTNode for Decorated<N> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let decorators = decorators_from_reader(reader, state, settings)?;
         N::from_reader(reader, state, settings).map(|on| Self { on, decorators })
@@ -125,7 +125,7 @@ impl<N: ASTNode> ASTNode for Decorated<N> {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         self.to_string_from_buffer_just_decorators(buf, settings, depth);
@@ -144,7 +144,7 @@ impl<U> Decorated<U> {
     pub(crate) fn to_string_from_buffer_just_decorators<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_decorators {
@@ -163,7 +163,7 @@ impl<U> Decorated<U> {
 pub(crate) fn decorators_from_reader(
     reader: &mut impl TokenReader<TSXToken, Span>,
     state: &mut crate::ParsingState,
-    settings: &ParseSettings,
+    settings: &ParseOptions,
 ) -> ParseResult<Vec<Decorator>> {
     let mut decorators = Vec::new();
     while let Some(Token(TSXToken::At, _)) = reader.peek() {

--- a/parser/src/extensions/is_expression.rs
+++ b/parser/src/extensions/is_expression.rs
@@ -8,16 +8,15 @@ use visitable_derive::Visitable;
 
 use crate::{
     errors::parse_lexing_error,
-    expressions::{ExpressionId, ExpressionOrBlock, MultipleExpression},
-    ASTNode, Keyword, TypeReference,
+    expressions::{ExpressionOrBlock, MultipleExpression},
+    ASTNode, Keyword, TypeAnnotation,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
 pub struct IsExpression {
     pub is: Keyword<Is>,
     pub matcher: Box<MultipleExpression>,
-    pub branches: Vec<(TypeReference, ExpressionOrBlock)>,
-    pub expression_id: ExpressionId,
+    pub branches: Vec<(TypeAnnotation, ExpressionOrBlock)>,
     pub position: Span,
 }
 
@@ -39,7 +38,7 @@ impl ASTNode for IsExpression {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, source_map::Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> crate::ParseResult<Self> {
         let span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Is))?;
         let is = Keyword::new(span);
@@ -49,7 +48,7 @@ impl ASTNode for IsExpression {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("is (");
@@ -70,7 +69,7 @@ impl ASTNode for IsExpression {
 pub(crate) fn is_expression_from_reader_sub_is_keyword(
     reader: &mut impl TokenReader<TSXToken, source_map::Span>,
     state: &mut crate::ParsingState,
-    settings: &crate::ParseSettings,
+    settings: &crate::ParseOptions,
     is: Keyword<Is>,
 ) -> Result<IsExpression, crate::ParseError> {
     reader.expect_next(TSXToken::OpenParentheses)?;
@@ -79,18 +78,17 @@ pub(crate) fn is_expression_from_reader_sub_is_keyword(
     reader.expect_next(TSXToken::OpenBrace)?;
     let mut branches = Vec::new();
     loop {
-        let type_reference = TypeReference::from_reader(reader, state, settings)?;
+        let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
         reader.expect_next(TSXToken::Arrow)?;
         let body = ExpressionOrBlock::from_reader(reader, state, settings)?;
         let tokenizer_lib::Token(next, pos) = reader.next().ok_or_else(parse_lexing_error)?;
-        branches.push((type_reference, body));
+        branches.push((type_annotation, body));
         if next == TSXToken::CloseBrace {
             return Ok(IsExpression {
                 position: is.1.union(&pos),
                 is,
                 matcher: Box::new(matcher),
                 branches,
-                expression_id: ExpressionId::new(),
             });
         } else if next != TSXToken::Comma {
             todo!("Error")

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use crate::{
-    parameters::*, parse_bracketed, to_string_bracketed, ASTNode, Block, ChainVariable,
-    ExpressionOrStatementPosition, ExpressionPosition, GenericTypeConstraint, Keyword, ParseResult,
-    ParseSettings, TSXToken, TypeReference, VisitSettings, Visitable,
+    parameters::*, parse_bracketed, to_string_bracketed, ASTNode, Block,
+    ExpressionOrStatementPosition, ExpressionPosition, GenericTypeConstraint, Keyword,
+    ParseOptions, ParseResult, TSXToken, TypeAnnotation, VisitSettings, Visitable,
 };
 use crate::{tsx_keywords, TSXKeyword};
 use derive_debug_extras::DebugExtras;
@@ -59,21 +59,19 @@ pub trait FunctionBased: Debug + Clone + PartialEq + Eq + Send + Sync {
     /// The body of the function
     type Body: ASTNode;
 
-    fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable;
-
     fn header_left(header: &Self::Header) -> Option<Cow<Span>>;
 
     fn header_and_name_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<(Self::Header, Self::Name)>;
 
     fn header_and_name_to_string_from_buffer<T: ToString>(
         buf: &mut T,
         header: &Self::Header,
         name: &Self::Name,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     );
 
@@ -86,7 +84,7 @@ pub trait FunctionBased: Debug + Clone + PartialEq + Eq + Send + Sync {
     fn parameters_from_reader<T: ToString>(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<FunctionParameters> {
         FunctionParameters::from_reader(reader, state, settings)
     }
@@ -95,7 +93,7 @@ pub trait FunctionBased: Debug + Clone + PartialEq + Eq + Send + Sync {
     fn parameters_to_string_from_buffer<T: ToString>(
         buf: &mut T,
         parameters: &FunctionParameters,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         parameters.to_string_from_buffer(buf, settings, depth);
@@ -104,7 +102,7 @@ pub trait FunctionBased: Debug + Clone + PartialEq + Eq + Send + Sync {
     /// For [crate::ArrowFunction]
     fn parameter_body_boundary_token_to_string_from_buffer<T: ToString>(
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
     ) {
         settings.add_gap(buf);
     }
@@ -122,7 +120,7 @@ pub struct FunctionBase<T: FunctionBased> {
     pub name: T::Name,
     pub type_parameters: Option<Vec<GenericTypeConstraint>>,
     pub parameters: FunctionParameters,
-    pub return_type: Option<TypeReference>,
+    pub return_type: Option<TypeAnnotation>,
     pub body: T::Body,
 }
 
@@ -142,7 +140,7 @@ impl<T: FunctionBased + 'static> ASTNode for FunctionBase<T> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let (header, name) = T::header_and_name_from_reader(reader, state, settings)?;
         Self::from_reader_with_header_and_name(reader, state, settings, header, name)
@@ -151,7 +149,7 @@ impl<T: FunctionBased + 'static> ASTNode for FunctionBase<T> {
     fn to_string_from_buffer<TS: source_map::ToString>(
         &self,
         buf: &mut TS,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         T::header_and_name_to_string_from_buffer(buf, &self.header, &self.name, settings, depth);
@@ -181,7 +179,7 @@ impl<T: FunctionBased> FunctionBase<T> {
     pub(crate) fn from_reader_with_header_and_name(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         header: T::Header,
         name: T::Name,
     ) -> ParseResult<Self> {
@@ -197,7 +195,7 @@ impl<T: FunctionBased> FunctionBase<T> {
         let return_type = reader
             .conditional_next(|tok| matches!(tok, TSXToken::Colon))
             .is_some()
-            .then(|| TypeReference::from_reader(reader, state, settings))
+            .then(|| TypeAnnotation::from_reader(reader, state, settings))
             .transpose()?;
 
         if let Some(token) = T::get_parameter_body_boundary_token() {
@@ -264,18 +262,18 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
     type Header = FunctionHeader;
     type Name = T::Name;
 
-    fn get_chain_variable(_this: &FunctionBase<Self>) -> crate::ChainVariable {
-        todo!()
-        // crate::ChainVariable::UnderExpressionFunctionBlock(self.base.body.1, self.expression_id)
-    }
+    // fn get_chain_variable(_this: &FunctionBase<Self>) -> crate::ChainVariable {
+    // 	todo!()
+    // 	// crate::ChainVariable::UnderExpressionFunctionBlock(self.base.body.1, self.expression_id)
+    // }
 
     fn header_and_name_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> ParseResult<(Self::Header, Self::Name)> {
         let header = FunctionHeader::from_reader(reader, state, settings)?;
-        let (name, _) = T::from_reader(reader, state, settings)?;
+        let name = T::from_reader(reader, state, settings)?;
         Ok((header, name))
     }
 
@@ -283,7 +281,7 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
         buf: &mut U,
         header: &Self::Header,
         name: &Self::Name,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         header.to_string_from_buffer(buf, settings, depth);
@@ -354,7 +352,7 @@ impl ASTNode for FunctionHeader {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         _state: &mut crate::ParsingState,
-        _settings: &ParseSettings,
+        _settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let async_keyword = reader
             .conditional_next(|tok| matches!(tok, TSXToken::Keyword(TSXKeyword::Async)))
@@ -389,7 +387,7 @@ impl ASTNode for FunctionHeader {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
         if self.is_async() {

--- a/parser/src/generator_helpers.rs
+++ b/parser/src/generator_helpers.rs
@@ -1,7 +1,4 @@
-use crate::{
-    expressions::ExpressionId, ASTNode, Expression, PropertyReference, Statement, VariableId,
-    VariableIdentifier,
-};
+use crate::{ASTNode, Expression, PropertyReference, Statement, VariableIdentifier};
 
 use source_map::Span;
 
@@ -20,18 +17,13 @@ pub struct Ident<'a>(&'a str);
 
 impl<'a> IntoAST<Expression> for Ident<'a> {
     fn into_ast(self) -> Expression {
-        Expression::VariableReference(self.0.to_owned(), Span::NULL_SPAN, ExpressionId::new())
+        Expression::VariableReference(self.0.to_owned(), Span::NULL_SPAN)
     }
 }
 
 impl<'a> IntoAST<Expression> for &'a str {
     fn into_ast(self) -> Expression {
-        Expression::StringLiteral(
-            self.to_owned(),
-            crate::Quoted::Double,
-            Span::NULL_SPAN,
-            ExpressionId::new(),
-        )
+        Expression::StringLiteral(self.to_owned(), crate::Quoted::Double, Span::NULL_SPAN)
     }
 }
 
@@ -43,27 +35,19 @@ impl<'a> IntoAST<PropertyReference> for &'a str {
 
 impl<'a> IntoAST<VariableIdentifier> for &'a str {
     fn into_ast(self) -> VariableIdentifier {
-        VariableIdentifier::Standard(self.to_owned(), VariableId::new(), Span::NULL_SPAN)
+        VariableIdentifier::Standard(self.to_owned(), Span::NULL_SPAN)
     }
 }
 
 impl IntoAST<Expression> for usize {
     fn into_ast(self) -> Expression {
-        Expression::NumberLiteral(
-            crate::NumberStructure::Number(self as f64),
-            Span::NULL_SPAN,
-            ExpressionId::new(),
-        )
+        Expression::NumberLiteral(crate::NumberStructure::Number(self as f64), Span::NULL_SPAN)
     }
 }
 
 impl IntoAST<Expression> for f64 {
     fn into_ast(self) -> Expression {
-        Expression::NumberLiteral(
-            crate::NumberStructure::Number(self),
-            Span::NULL_SPAN,
-            ExpressionId::new(),
-        )
+        Expression::NumberLiteral(crate::NumberStructure::Number(self), Span::NULL_SPAN)
     }
 }
 

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -38,8 +38,8 @@ pub enum BinaryAssignmentOperator {
 
     AddAssign, SubtractAssign, MultiplyAssign, DivideAssign, ModuloAssign, ExponentAssign,
     LogicalAndAssign, LogicalOrAssign,
-    BitwiseShiftLeftAssign, BitwiseShiftRightAssign, BitwiseShiftRightUnsignedAssign,
-    BitwiseAndAssign, BitwiseXOrAssign, BitOrAssign,
+    BitwiseShiftLeftAssign, BitwiseShiftRightAssign, BitwiseShiftRightUnsigned,
+    BitwiseAndAssign, BitwiseXorAssign, BitwiseOrAssign,
 }
 
 #[rustfmt::skip]
@@ -247,10 +247,10 @@ impl Operator for BinaryAssignmentOperator {
             BinaryAssignmentOperator::ExponentAssign => "**=",
             BinaryAssignmentOperator::BitwiseShiftLeftAssign => "<<=",
             BinaryAssignmentOperator::BitwiseShiftRightAssign => ">>=",
-            BinaryAssignmentOperator::BitwiseShiftRightUnsignedAssign => ">>>=",
+            BinaryAssignmentOperator::BitwiseShiftRightUnsigned => ">>>=",
             BinaryAssignmentOperator::BitwiseAndAssign => "&=",
-            BinaryAssignmentOperator::BitwiseXOrAssign => "^=",
-            BinaryAssignmentOperator::BitOrAssign => "|=",
+            BinaryAssignmentOperator::BitwiseXorAssign => "^=",
+            BinaryAssignmentOperator::BitwiseOrAssign => "|=",
             BinaryAssignmentOperator::LogicalAndAssign => "&&=",
             BinaryAssignmentOperator::LogicalOrAssign => "||=",
         }
@@ -332,12 +332,12 @@ impl From<BinaryAssignmentOperator> for BinaryOperator {
             BinaryAssignmentOperator::LogicalOrAssign => BinaryOperator::LogicalOr,
             BinaryAssignmentOperator::BitwiseShiftLeftAssign => BinaryOperator::BitwiseShiftLeft,
             BinaryAssignmentOperator::BitwiseShiftRightAssign => BinaryOperator::BitwiseShiftRight,
-            BinaryAssignmentOperator::BitwiseShiftRightUnsignedAssign => {
+            BinaryAssignmentOperator::BitwiseShiftRightUnsigned => {
                 BinaryOperator::BitwiseShiftRightUnsigned
             }
             BinaryAssignmentOperator::BitwiseAndAssign => BinaryOperator::BitwiseAnd,
-            BinaryAssignmentOperator::BitwiseXOrAssign => BinaryOperator::BitwiseXOr,
-            BinaryAssignmentOperator::BitOrAssign => BinaryOperator::BitwiseOr,
+            BinaryAssignmentOperator::BitwiseXorAssign => BinaryOperator::BitwiseXOr,
+            BinaryAssignmentOperator::BitwiseOrAssign => BinaryOperator::BitwiseOr,
         }
     }
 }
@@ -354,8 +354,18 @@ impl TryFrom<&TSXToken> for BinaryAssignmentOperator {
             TSXToken::ExponentAssign => Ok(BinaryAssignmentOperator::ExponentAssign),
             TSXToken::LogicalAndAssign => Ok(BinaryAssignmentOperator::LogicalAndAssign),
             TSXToken::LogicalOrAssign => Ok(BinaryAssignmentOperator::LogicalOrAssign),
-            TSXToken::BitwiseOrAssign => Ok(BinaryAssignmentOperator::BitOrAssign),
-            TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXOrAssign),
+            TSXToken::BitwiseAndAssign => Ok(BinaryAssignmentOperator::BitwiseAndAssign),
+            TSXToken::BitwiseOrAssign => Ok(BinaryAssignmentOperator::BitwiseOrAssign),
+            TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXorAssign),
+            TSXToken::BitwiseShiftLeftAssign => {
+                Ok(BinaryAssignmentOperator::BitwiseShiftLeftAssign)
+            }
+            TSXToken::BitwiseShiftRightAssign => {
+                Ok(BinaryAssignmentOperator::BitwiseShiftRightAssign)
+            }
+            TSXToken::BitwiseShiftRightUnsigned => {
+                Ok(BinaryAssignmentOperator::BitwiseShiftRightUnsigned)
+            }
             TSXToken::NullishCoalescingAssign => {
                 Ok(BinaryAssignmentOperator::LogicalNullishAssignment)
             }

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -9,21 +9,22 @@ use visitable_derive::Visitable;
 
 use crate::{
     errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Expression, ParseError,
-    ParseResult, TypeReference, VariableField, VariableFieldInSourceCode, VariableId,
-    VariableIdentifier, WithComment,
+    ParseResult, TypeAnnotation, VariableField, VariableFieldInSourceCode, VariableIdentifier,
+    WithComment,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
 pub struct Parameter {
     pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
-    pub type_reference: Option<TypeReference>,
+    pub type_annotation: Option<TypeAnnotation>,
+    pub additionally: Option<ParameterData>,
 }
 
 // TODO not sure whether parameter should implement ASTNode
 impl Parameter {
     pub fn get_position(&self) -> Cow<Span> {
         let position = self.name.get_position();
-        if let Some(tr) = &self.type_reference {
+        if let Some(tr) = &self.type_annotation {
             Cow::Owned(position.union(&tr.get_position()))
         } else {
             position
@@ -32,23 +33,15 @@ impl Parameter {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-pub enum OptionalOrWithDefaultValueParameter {
-    Optional {
-        // WithComment<VariableField<VariableFieldInSourceCode>>
-        name: VariableIdentifier,
-        type_reference: Option<TypeReference>,
-    },
-    WithDefaultValue {
-        name: WithComment<VariableField<VariableFieldInSourceCode>>,
-        type_reference: Option<TypeReference>,
-        value: Box<Expression>,
-    },
+pub enum ParameterData {
+    Optional,
+    WithDefaultValue(Box<Expression>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
 pub struct SpreadParameter {
     pub name: VariableIdentifier,
-    pub type_reference: Option<TypeReference>,
+    pub type_annotation: Option<TypeAnnotation>,
 }
 
 /// TODO need to something special to not enable `OptionalFunctionParameter::WithValue` in interfaces and other
@@ -56,7 +49,6 @@ pub struct SpreadParameter {
 #[derive(Debug, Clone, PartialEqExtras, Visitable)]
 pub struct FunctionParameters {
     pub parameters: Vec<Parameter>,
-    pub optional_parameters: Vec<OptionalOrWithDefaultValueParameter>,
     pub rest_parameter: Option<Box<SpreadParameter>>,
     #[partial_eq_ignore]
     pub position: Span,
@@ -72,7 +64,7 @@ impl ASTNode for FunctionParameters {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> ParseResult<Self> {
         let open_paren_span = reader.expect_next(TSXToken::OpenParentheses)?;
         Self::from_reader_sub_open_parenthesis(reader, state, settings, open_paren_span)
@@ -81,12 +73,11 @@ impl ASTNode for FunctionParameters {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         let FunctionParameters {
             parameters,
-            optional_parameters,
             rest_parameter,
             ..
         } = self;
@@ -95,50 +86,24 @@ impl ASTNode for FunctionParameters {
             at_end,
             Parameter {
                 name,
-                type_reference,
+                type_annotation,
+                additionally,
                 ..
             },
         ) in parameters.iter().endiate()
         {
             // decorators_to_string_from_buffer(decorators, buf, settings, depth);
             name.to_string_from_buffer(buf, settings, depth);
-            if let (true, Some(ref type_reference)) = (settings.include_types, type_reference) {
-                buf.push_str(": ");
-                type_reference.to_string_from_buffer(buf, settings, depth);
-            }
-            if !at_end || !optional_parameters.is_empty() || rest_parameter.is_some() {
-                buf.push(',');
-                settings.add_gap(buf);
-            }
-        }
-        for (at_end, parameter) in optional_parameters.iter().endiate() {
-            match parameter {
-                OptionalOrWithDefaultValueParameter::Optional {
-                    name,
-                    type_reference,
-                    ..
-                } => {
-                    buf.push_str(name.as_str());
+            if let (true, Some(ref type_annotation)) = (settings.include_types, type_annotation) {
+                if let Some(ParameterData::Optional) = additionally {
                     buf.push('?');
-                    if let (true, Some(type_reference)) = (settings.include_types, type_reference) {
-                        buf.push_str(": ");
-                        type_reference.to_string_from_buffer(buf, settings, depth);
-                    }
                 }
-                OptionalOrWithDefaultValueParameter::WithDefaultValue {
-                    name,
-                    type_reference,
-                    value,
-                    ..
-                } => {
-                    name.to_string_from_buffer(buf, settings, depth);
-                    if let (true, Some(type_reference)) = (settings.include_types, type_reference) {
-                        buf.push_str(": ");
-                        type_reference.to_string_from_buffer(buf, settings, depth);
-                    }
-                    buf.push_str(if settings.pretty { " = " } else { "=" });
-                    value.to_string_from_buffer(buf, settings, depth);
-                }
+                buf.push_str(": ");
+                type_annotation.to_string_from_buffer(buf, settings, depth);
+            }
+            if let Some(ParameterData::WithDefaultValue(value)) = additionally {
+                buf.push_str(if settings.pretty { " = " } else { "=" });
+                value.to_string_from_buffer(buf, settings, depth);
             }
             if !at_end || rest_parameter.is_some() {
                 buf.push(',');
@@ -148,9 +113,9 @@ impl ASTNode for FunctionParameters {
         if let Some(rest_parameter) = rest_parameter {
             buf.push_str("...");
             buf.push_str(rest_parameter.name.as_str());
-            if let Some(ref type_reference) = rest_parameter.type_reference {
+            if let Some(ref type_annotation) = rest_parameter.type_annotation {
                 buf.push_str(": ");
-                type_reference.to_string_from_buffer(buf, settings, depth);
+                type_annotation.to_string_from_buffer(buf, settings, depth);
             }
         }
         buf.push(')');
@@ -161,11 +126,10 @@ impl FunctionParameters {
     pub(crate) fn from_reader_sub_open_parenthesis(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
         start_pos: Span,
     ) -> Result<FunctionParameters, ParseError> {
         let mut parameters = Vec::new();
-        let mut optional_parameters = Vec::new();
         let mut rest_parameter = None;
 
         loop {
@@ -182,33 +146,34 @@ impl FunctionParameters {
                     reader.next().ok_or_else(parse_lexing_error)?,
                     "spread function parameter",
                 )?;
-                let type_reference = if reader
+                let type_annotation = if reader
                     .conditional_next(|tok| matches!(tok, TSXToken::Colon))
                     .is_some()
                 {
-                    Some(TypeReference::from_reader(reader, state, settings)?)
+                    Some(TypeAnnotation::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
                 rest_parameter = Some(Box::new(SpreadParameter {
-                    name: VariableIdentifier::Standard(name, VariableId::new(), name_pos),
-                    type_reference,
+                    name: VariableIdentifier::Standard(name, name_pos),
+                    type_annotation,
                 }));
                 break;
             } else {
                 let name = WithComment::<VariableField<VariableFieldInSourceCode>>::from_reader(
                     reader, state, settings,
                 )?;
-                let (is_optional, type_reference) = match reader.peek() {
+
+                let (is_optional, type_annotation) = match reader.peek() {
                     Some(Token(TSXToken::Colon, _)) => {
                         reader.next();
-                        let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                        (false, Some(type_reference))
+                        let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                        (false, Some(type_annotation))
                     }
                     Some(Token(TSXToken::OptionalMember, _)) => {
                         reader.next();
-                        let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                        (true, Some(type_reference))
+                        let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                        (true, Some(type_annotation))
                     }
                     Some(Token(TSXToken::QuestionMark, _)) => {
                         let Token(_, _) = reader.next().unwrap();
@@ -226,53 +191,24 @@ impl FunctionParameters {
                             pos,
                         ));
                     }
-                    Some(Expression::from_reader(reader, state, settings)?)
+                    Some(Box::new(Expression::from_reader(reader, state, settings)?))
                 } else {
                     None
                 };
 
-                match (is_optional, value) {
+                let additionally = match (is_optional, value) {
                     (true, Some(_)) => unreachable!("caught earlier by error"),
                     // =
-                    (false, Some(value)) => {
-                        optional_parameters.push(
-                            OptionalOrWithDefaultValueParameter::WithDefaultValue {
-                                name,
-                                type_reference,
-                                value: Box::new(value),
-                            },
-                        );
-                    }
+                    (false, Some(value)) => Some(ParameterData::WithDefaultValue(value)),
                     // ?:
-                    (true, None) => {
-                        let name = if let VariableField::Name(VariableIdentifier::Standard(
-                            name,
-                            variable_id,
-                            position,
-                        )) = name.unwrap_ast()
-                        {
-                            VariableIdentifier::Standard(name, variable_id, position)
-                        } else {
-                            todo!("error")
-                        };
-                        optional_parameters.push(OptionalOrWithDefaultValueParameter::Optional {
-                            name,
-                            type_reference,
-                        });
-                    }
-                    (false, None) => {
-                        if !optional_parameters.is_empty() {
-                            return Err(ParseError::new(
-                                crate::ParseErrors::NonOptionalFunctionParameterAfterOptionalFunctionParameter,
-								name.get_position().into_owned()
-                            ));
-                        }
-                        parameters.push(Parameter {
-                            name,
-                            type_reference,
-                        });
-                    }
-                }
+                    (true, None) => Some(ParameterData::Optional),
+                    (false, None) => None,
+                };
+                parameters.push(Parameter {
+                    name,
+                    type_annotation,
+                    additionally,
+                });
             }
             if let Some(Token(TSXToken::Comma, _)) = reader.peek() {
                 reader.next();
@@ -284,7 +220,6 @@ impl FunctionParameters {
         Ok(FunctionParameters {
             position: start_pos.union(&end_span),
             parameters,
-            optional_parameters,
             rest_parameter,
         })
     }

--- a/parser/src/property_key.rs
+++ b/parser/src/property_key.rs
@@ -6,39 +6,8 @@ use tokenizer_lib::{Token, TokenReader};
 
 use crate::{
     errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Expression, NumberStructure,
-    ParseResult, ParseSettings,
+    ParseOptions, ParseResult,
 };
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
-pub struct PropertyId(u16);
-
-impl PropertyId {
-    pub fn new() -> Self {
-        use std::sync::atomic::{AtomicU16, Ordering};
-
-        static PROPERTY_ID_COUNTER: AtomicU16 = AtomicU16::new(2000);
-        Self(PROPERTY_ID_COUNTER.fetch_add(1, Ordering::SeqCst))
-    }
-
-    pub fn new_known(id: u16) -> Self {
-        Self(id)
-    }
-
-    pub fn unwrap_counter(&self) -> u16 {
-        self.0
-    }
-}
-
-// TODO not sure
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for PropertyId {
-    fn append_to_token_stream(
-        &self,
-        token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-    ) {
-        token_stream.extend(self_rust_tokenize::quote!(PropertyId::new()))
-    }
-}
 
 /// A key for a member in a class or object literal
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -47,29 +16,20 @@ impl self_rust_tokenize::SelfRustTokenize for PropertyId {
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
 pub enum PropertyKey {
-    Ident(String, PropertyId, Span),
-    StringLiteral(String, PropertyId, Span),
-    NumberLiteral(NumberStructure, PropertyId, Span),
+    Ident(String, Span),
+    StringLiteral(String, Span),
+    NumberLiteral(NumberStructure, Span),
     /// Includes anything in the `[...]` maybe a symbol
-    Computed(Box<Expression>, PropertyId, Span),
+    Computed(Box<Expression>, Span),
 }
 
 impl PropertyKey {
-    pub fn get_property_id(&self) -> PropertyId {
-        match self {
-            PropertyKey::Ident(_, variable_id, _)
-            | PropertyKey::StringLiteral(_, variable_id, _)
-            | PropertyKey::NumberLiteral(_, variable_id, _)
-            | PropertyKey::Computed(_, variable_id, _) => *variable_id,
-        }
-    }
-
     pub fn get_position(&self) -> Cow<Span> {
         match self {
-            PropertyKey::Ident(_, _, pos)
-            | PropertyKey::StringLiteral(_, _, pos)
-            | PropertyKey::NumberLiteral(_, _, pos)
-            | PropertyKey::Computed(_, _, pos) => Cow::Borrowed(pos),
+            PropertyKey::Ident(_, pos)
+            | PropertyKey::StringLiteral(_, pos)
+            | PropertyKey::NumberLiteral(_, pos)
+            | PropertyKey::Computed(_, pos) => Cow::Borrowed(pos),
         }
     }
 }
@@ -77,10 +37,8 @@ impl PropertyKey {
 impl PartialEq<str> for PropertyKey {
     fn eq(&self, other: &str) -> bool {
         match self {
-            PropertyKey::Ident(name, _, _) | PropertyKey::StringLiteral(name, _, _) => {
-                name == other
-            }
-            PropertyKey::NumberLiteral(_, _, _) | PropertyKey::Computed(_, _, _) => false,
+            PropertyKey::Ident(name, _) | PropertyKey::StringLiteral(name, _) => name == other,
+            PropertyKey::NumberLiteral(_, _) | PropertyKey::Computed(_, _) => false,
         }
     }
 }
@@ -88,40 +46,37 @@ impl PartialEq<str> for PropertyKey {
 impl ASTNode for PropertyKey {
     fn get_position(&self) -> Cow<Span> {
         match self {
-            PropertyKey::Ident(_, _, pos)
-            | PropertyKey::StringLiteral(_, _, pos)
-            | PropertyKey::NumberLiteral(_, _, pos)
-            | PropertyKey::Computed(_, _, pos) => Cow::Borrowed(pos),
+            PropertyKey::Ident(_, pos)
+            | PropertyKey::StringLiteral(_, pos)
+            | PropertyKey::NumberLiteral(_, pos)
+            | PropertyKey::Computed(_, pos) => Cow::Borrowed(pos),
         }
     }
 
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         match reader.next().ok_or_else(parse_lexing_error)? {
             Token(TSXToken::DoubleQuotedStringLiteral(content), position)
             | Token(TSXToken::SingleQuotedStringLiteral(content), position) => {
-                Ok(Self::StringLiteral(content, PropertyId::new(), position))
+                Ok(Self::StringLiteral(content, position))
             }
-            Token(TSXToken::NumberLiteral(value), position) => Ok(Self::NumberLiteral(
-                value.parse().unwrap(),
-                PropertyId::new(),
-                position,
-            )),
+            Token(TSXToken::NumberLiteral(value), position) => {
+                Ok(Self::NumberLiteral(value.parse().unwrap(), position))
+            }
             Token(TSXToken::OpenBracket, start_pos) => {
                 let expression = Expression::from_reader(reader, state, settings)?;
                 let end_pos = reader.expect_next(TSXToken::CloseBracket)?;
                 Ok(Self::Computed(
                     Box::new(expression),
-                    PropertyId::new(),
                     start_pos.union(&end_pos),
                 ))
             }
             token => {
                 let (name, position) = token_as_identifier(token, "property key")?;
-                Ok(Self::Ident(name, PropertyId::new(), position))
+                Ok(Self::Ident(name, position))
             }
         }
     }
@@ -129,18 +84,18 @@ impl ASTNode for PropertyKey {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
-            Self::Ident(ident, _, _pos) => buf.push_str(ident.as_str()),
-            Self::NumberLiteral(number, _, _) => buf.push_str(&number.to_string()),
-            Self::StringLiteral(string, _, _) => {
+            Self::Ident(ident, _pos) => buf.push_str(ident.as_str()),
+            Self::NumberLiteral(number, _) => buf.push_str(&number.to_string()),
+            Self::StringLiteral(string, _) => {
                 buf.push('"');
                 buf.push_str(string.as_str());
                 buf.push('"');
             }
-            Self::Computed(expression, _, _) => {
+            Self::Computed(expression, _) => {
                 buf.push('[');
                 expression.to_string_from_buffer(buf, settings, depth);
                 buf.push(']');

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
 use crate::{
-    block::BlockOrSingleStatement, expressions::MultipleExpression, ParseSettings, TSXKeyword,
+    block::BlockOrSingleStatement, expressions::MultipleExpression, ParseOptions, TSXKeyword,
 };
+use iterator_endiate::EndiateIteratorExt;
 use visitable_derive::Visitable;
 
 use super::{ASTNode, ParseResult, Span, TSXToken, Token, TokenReader};
@@ -48,7 +49,7 @@ impl ASTNode for IfStatement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::If))?;
         reader.expect_next(TSXToken::OpenParentheses)?;
@@ -95,7 +96,7 @@ impl ASTNode for IfStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("if");
@@ -105,9 +106,25 @@ impl ASTNode for IfStatement {
         buf.push(')');
         settings.add_gap(buf);
         self.inner.to_string_from_buffer(buf, settings, depth + 1);
-        for else_statement in self.else_conditions.iter() {
+        if !settings.pretty
+            && matches!(self.inner, BlockOrSingleStatement::SingleStatement(_))
+            && (!self.else_conditions.is_empty() || self.trailing_else.is_some())
+        {
+            buf.push(';');
+        }
+
+        for (at_end, else_statement) in self.else_conditions.iter().endiate() {
             settings.add_gap(buf);
             else_statement.to_string_from_buffer(buf, settings, depth);
+            if !settings.pretty
+                && matches!(
+                    else_statement.inner,
+                    BlockOrSingleStatement::SingleStatement(_)
+                )
+                && at_end
+            {
+                buf.push(';');
+            }
         }
         if let Some(else_statement) = &self.trailing_else {
             settings.add_gap(buf);
@@ -120,7 +137,7 @@ impl ASTNode for ConditionalElseStatement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let else_position = reader.expect_next(TSXToken::Keyword(TSXKeyword::Else))?;
         Self::from_reader_sub_without_else(reader, state, settings, else_position)
@@ -133,7 +150,7 @@ impl ASTNode for ConditionalElseStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("else if");
@@ -150,7 +167,7 @@ impl ConditionalElseStatement {
     fn from_reader_sub_without_else(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         else_position: Span,
     ) -> ParseResult<Self> {
         reader.expect_next(TSXToken::Keyword(TSXKeyword::If))?;
@@ -170,7 +187,7 @@ impl ASTNode for UnconditionalElseStatement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let else_position = reader.expect_next(TSXToken::Keyword(TSXKeyword::Else))?;
         Self::from_reader_sub_without_else(reader, state, settings, else_position)
@@ -183,10 +200,13 @@ impl ASTNode for UnconditionalElseStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("else");
+        if !settings.pretty && matches!(self.inner, BlockOrSingleStatement::SingleStatement(_)) {
+            buf.push(' ');
+        }
         settings.add_gap(buf);
         self.inner.to_string_from_buffer(buf, settings, depth + 1);
     }
@@ -196,7 +216,7 @@ impl UnconditionalElseStatement {
     fn from_reader_sub_without_else(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         else_position: Span,
     ) -> ParseResult<Self> {
         let statements = BlockOrSingleStatement::from_reader(reader, state, settings)?;

--- a/parser/src/statements/mod.rs
+++ b/parser/src/statements/mod.rs
@@ -6,7 +6,6 @@ mod while_statement;
 
 use crate::{
     declarations::variable::{declarations_to_string, VariableDeclarationItem},
-    expect_semi_colon,
     tokens::token_as_identifier,
     tsx_keywords,
 };
@@ -15,8 +14,8 @@ use derive_partial_eq_extras::PartialEqExtras;
 use std::{borrow::Cow, fmt::Debug};
 
 use super::{
-    expressions::MultipleExpression, ASTNode, Block, CursorId, Expression, Keyword, ParseResult,
-    ParseSettings, Span, TSXKeyword, TSXToken, Token, TokenReader,
+    expressions::MultipleExpression, ASTNode, Block, CursorId, Expression, Keyword, ParseOptions,
+    ParseResult, Span, TSXKeyword, TSXToken, Token, TokenReader,
 };
 use crate::errors::parse_lexing_error;
 pub use for_statement::{ForLoopCondition, ForLoopStatement, ForLoopStatementInitializer};
@@ -54,7 +53,7 @@ pub enum Statement {
     Continue(Option<String>, Span),
     Break(Option<String>, Span),
     /// e.g `throw ...`
-    Throw(Keyword<tsx_keywords::Throw>, Box<Expression>),
+    Throw(Keyword<tsx_keywords::Throw>, Box<MultipleExpression>),
     // Comments
     Comment(String, Span),
     MultiLineComment(String, Span),
@@ -64,6 +63,8 @@ pub enum Statement {
         statement: Box<Statement>,
     },
     VarVariable(VarVariableStatement),
+    // TODO position
+    Empty(Span),
     /// TODO under cfg
     #[self_tokenize_field(0)]
     Cursor(#[visit_skip_field] CursorId<Statement>, Span),
@@ -81,6 +82,7 @@ impl ASTNode for Statement {
             | Statement::Break(_, pos)
             | Statement::Cursor(_, pos)
             | Statement::Comment(_, pos)
+            | Statement::Empty(pos)
             | Statement::Labelled { position: pos, .. }
             | Statement::MultiLineComment(_, pos) => Cow::Borrowed(pos),
             Statement::Return(kw, expr) => {
@@ -104,7 +106,7 @@ impl ASTNode for Statement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         if let Some(Token(TSXToken::Colon, _)) = reader.peek_n(1) {
             let (name, label_name_pos) = token_as_identifier(reader.next().unwrap(), "label name")?;
@@ -130,12 +132,11 @@ impl ASTNode for Statement {
             }
             TSXToken::Keyword(TSXKeyword::Var) => {
                 let stmt = VarVariableStatement::from_reader(reader, state, settings)?;
-                expect_semi_colon(reader)?;
                 Ok(Statement::VarVariable(stmt))
             }
             TSXToken::Keyword(TSXKeyword::Throw) => {
                 let Token(_, throw_pos) = reader.next().unwrap();
-                let expression = Expression::from_reader(reader, state, settings)?;
+                let expression = ASTNode::from_reader(reader, state, settings)?;
                 Ok(Statement::Throw(
                     Keyword::new(throw_pos),
                     Box::new(expression),
@@ -221,6 +222,10 @@ impl ASTNode for Statement {
                     unreachable!()
                 }
             }
+            TSXToken::SemiColon => {
+                let pos = reader.next().unwrap().1;
+                Ok(Statement::Empty(pos))
+            }
             // Finally ...!
             _ => {
                 let expr = MultipleExpression::from_reader(reader, state, settings)?;
@@ -232,7 +237,7 @@ impl ASTNode for Statement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -240,6 +245,9 @@ impl ASTNode for Statement {
                 if !settings.expect_cursors {
                     panic!("tried to to-string cursor")
                 }
+            }
+            Statement::Empty(..) => {
+                buf.push(';');
             }
             Statement::Return(_, expression) => {
                 buf.push_str("return");
@@ -329,7 +337,7 @@ impl Statement {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Visitable)]
+#[derive(Debug, PartialEq, Eq, Clone, Visitable)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
@@ -351,7 +359,7 @@ impl ASTNode for VarVariableStatement {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let keyword = Keyword::new(reader.expect_next(TSXToken::Keyword(TSXKeyword::Var))?);
         let mut declarations = Vec::new();
@@ -375,11 +383,10 @@ impl ASTNode for VarVariableStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("var ");
         declarations_to_string(&self.declarations, buf, settings, depth);
-        buf.push(';');
     }
 }

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
 use crate::{
-    errors::parse_lexing_error, ASTNode, Expression, ParseSettings, Statement, TSXKeyword, TSXToken,
+    errors::parse_lexing_error, ASTNode, Expression, ParseOptions, Statement, TSXKeyword, TSXToken,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
@@ -38,7 +38,7 @@ impl ASTNode for SwitchStatement {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Switch))?;
         reader.expect_next(crate::TSXToken::OpenParentheses)?;
@@ -97,7 +97,7 @@ impl ASTNode for SwitchStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("switch");

--- a/parser/src/statements/try_catch_statement.rs
+++ b/parser/src/statements/try_catch_statement.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-    ASTNode, Block, ParseError, ParseErrors, TSXKeyword, TSXToken, TypeReference, VariableField,
+    ASTNode, Block, ParseError, ParseErrors, TSXKeyword, TSXToken, TypeAnnotation, VariableField,
     VariableFieldInSourceCode, WithComment,
 };
 use source_map::Span;
@@ -18,7 +18,7 @@ pub type ExceptionVarField = WithComment<VariableField<VariableFieldInSourceCode
 pub struct TryCatchStatement {
     try_inner: Block,
     catch_inner: Option<Block>,
-    exception_var: Option<(ExceptionVarField, Option<TypeReference>)>,
+    exception_var: Option<(ExceptionVarField, Option<TypeAnnotation>)>,
     finally_inner: Option<Block>,
     position: Span,
 }
@@ -31,13 +31,13 @@ impl ASTNode for TryCatchStatement {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Try))?;
         let try_inner = Block::from_reader(reader, state, settings)?;
 
         let mut catch_inner: Option<Block> = None;
-        let mut exception_var: Option<(ExceptionVarField, Option<TypeReference>)> = None;
+        let mut exception_var: Option<(ExceptionVarField, Option<TypeAnnotation>)> = None;
 
         // Optional `catch` clause
         if let Some(Token(TSXToken::Keyword(TSXKeyword::Catch), _)) = reader.peek() {
@@ -52,10 +52,11 @@ impl ASTNode for TryCatchStatement {
                     )?;
 
                 // Optional type reference `catch (e: type)`
-                let mut exception_var_type: Option<TypeReference> = None;
+                let mut exception_var_type: Option<TypeAnnotation> = None;
                 if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
                     reader.expect_next(TSXToken::Colon)?;
-                    exception_var_type = Some(TypeReference::from_reader(reader, state, settings)?);
+                    exception_var_type =
+                        Some(TypeAnnotation::from_reader(reader, state, settings)?);
                 }
                 exception_var = Some((variable_field, exception_var_type));
 
@@ -97,7 +98,7 @@ impl ASTNode for TryCatchStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         // Required `try` block

--- a/parser/src/statements/while_statement.rs
+++ b/parser/src/statements/while_statement.rs
@@ -24,7 +24,7 @@ impl ASTNode for WhileStatement {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::While))?;
         reader.expect_next(TSXToken::OpenParentheses)?;
@@ -41,7 +41,7 @@ impl ASTNode for WhileStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("while");
@@ -75,7 +75,7 @@ impl ASTNode for DoWhileStatement {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Do))?;
         let inner = BlockOrSingleStatement::from_reader(reader, state, settings)?;
@@ -93,7 +93,7 @@ impl ASTNode for DoWhileStatement {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         buf.push_str("do");

--- a/parser/src/types/declares.rs
+++ b/parser/src/types/declares.rs
@@ -4,10 +4,12 @@ use tokenizer_lib::Token;
 
 use crate::{
     errors::parse_lexing_error, parse_bracketed, to_string_bracketed, tokens::token_as_identifier,
-    types::type_references::TypeReferenceFunctionParameters, ASTNode, Decorator,
-    GenericTypeConstraint, ParseResult, ParseSettings, Span, TSXKeyword, TSXToken, TokenReader,
-    TypeId, TypeReference, VariableId,
+    types::type_annotations::TypeAnnotationFunctionParameters, ASTNode, Decorator,
+    GenericTypeConstraint, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, TokenReader,
+    TypeAnnotation,
 };
+
+use super::AnnotationPerforms;
 
 /// A `declare var` thingy.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,8 +19,7 @@ use crate::{
 )]
 pub struct DeclareVariableDeclaration {
     pub name: String,
-    pub type_restriction: TypeReference,
-    pub variable_id: VariableId,
+    pub type_restriction: TypeAnnotation,
     pub decorators: Vec<Decorator>,
     pub position: Span,
 }
@@ -31,7 +32,7 @@ impl ASTNode for DeclareVariableDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Declare))?;
         Self::from_reader_sub_declare(reader, state, settings, Some(start_span), Vec::new())
@@ -40,7 +41,7 @@ impl ASTNode for DeclareVariableDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_types {
@@ -57,21 +58,20 @@ impl DeclareVariableDeclaration {
     pub fn from_reader_sub_declare(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         declare_span: Option<Span>,
         decorators: Vec<Decorator>,
     ) -> ParseResult<Self> {
         let var_pos = reader.expect_next(TSXToken::Keyword(TSXKeyword::Var))?;
         let (name, _) = token_as_identifier(reader.next().unwrap(), "declare variable name")?;
         reader.expect_next(TSXToken::Colon)?;
-        let type_restriction = TypeReference::from_reader(reader, state, settings)?;
+        let type_restriction = TypeAnnotation::from_reader(reader, state, settings)?;
         let position = declare_span
             .unwrap_or(var_pos)
             .union(&type_restriction.get_position());
         Ok(Self {
             name,
             type_restriction,
-            variable_id: VariableId::new(),
             position,
             decorators,
         })
@@ -86,9 +86,10 @@ impl DeclareVariableDeclaration {
 pub struct DeclareFunctionDeclaration {
     pub name: String,
     pub type_parameters: Option<Vec<GenericTypeConstraint>>,
-    pub parameters: TypeReferenceFunctionParameters,
-    pub return_type: Option<TypeReference>,
-    pub variable_id: VariableId,
+    pub parameters: TypeAnnotationFunctionParameters,
+    pub return_type: Option<TypeAnnotation>,
+    #[cfg(feature = "extras")]
+    pub performs: Option<AnnotationPerforms>,
     pub decorators: Vec<Decorator>,
     pub position: Span,
 }
@@ -101,7 +102,7 @@ impl ASTNode for DeclareFunctionDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         reader.expect_next(TSXToken::Keyword(TSXKeyword::Declare))?;
         Self::from_reader_sub_declare_with_decorators(reader, state, settings, Vec::new())
@@ -110,7 +111,7 @@ impl ASTNode for DeclareFunctionDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_types {
@@ -132,7 +133,7 @@ impl DeclareFunctionDeclaration {
     pub fn from_reader_sub_declare_with_decorators(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         decorators: Vec<Decorator>,
     ) -> ParseResult<Self> {
         let start_pos = reader.expect_next(TSXToken::Keyword(TSXKeyword::Function))?;
@@ -148,28 +149,39 @@ impl DeclareFunctionDeclaration {
         } else {
             None
         };
-        let parameters = TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+        let parameters = TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
         let return_type = if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
             reader.next();
-            let type_reference = TypeReference::from_reader(reader, state, settings)?;
-            Some(type_reference)
+            let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+            Some(type_annotation)
         } else {
             None
         };
+
+        #[cfg(feature = "extras")]
+        let performs =
+            if let Some(Token(TSXToken::Keyword(TSXKeyword::Performs), _)) = reader.peek() {
+                Some(AnnotationPerforms::from_reader(reader, state, settings)?)
+            } else {
+                None
+            };
+
         let position = start_pos.union(
             &return_type
                 .as_ref()
                 .map(ASTNode::get_position)
                 .unwrap_or(Cow::Borrowed(&parameters.position)),
         );
+
         Ok(Self {
             name,
             type_parameters,
             parameters,
             return_type,
             decorators,
-            variable_id: VariableId::new(),
             position,
+            #[cfg(feature = "extras")]
+            performs,
         })
     }
 }
@@ -178,9 +190,8 @@ impl DeclareFunctionDeclaration {
 pub struct DeclareClassDeclaration {
     pub name: String,
     pub type_parameters: Option<Vec<GenericTypeConstraint>>,
-    pub extends: Option<TypeReference>,
-    pub type_id: TypeId, // TODO:
-                         // members: Vec<DeclareClassMember>
+    pub extends: Option<TypeAnnotation>,
+    // members: Vec<DeclareClassMember>
 }
 
 impl ASTNode for DeclareClassDeclaration {
@@ -191,7 +202,7 @@ impl ASTNode for DeclareClassDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         reader.expect_next(TSXToken::Keyword(TSXKeyword::Declare))?;
         Self::from_reader_sub_declare(reader, state, settings)
@@ -200,7 +211,7 @@ impl ASTNode for DeclareClassDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         _buf: &mut T,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
         todo!()
@@ -211,7 +222,7 @@ impl DeclareClassDeclaration {
     pub(crate) fn from_reader_sub_declare(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         reader.expect_next(TSXToken::Keyword(TSXKeyword::Class))?;
         let (name, _) =
@@ -219,7 +230,7 @@ impl DeclareClassDeclaration {
         let extends = if let Some(Token(TSXToken::Keyword(TSXKeyword::Extends), _)) = reader.peek()
         {
             reader.next();
-            Some(TypeReference::from_reader(reader, state, settings)?)
+            Some(TypeAnnotation::from_reader(reader, state, settings)?)
         } else {
             None
         };
@@ -230,7 +241,6 @@ impl DeclareClassDeclaration {
             name,
             extends,
             type_parameters: None,
-            type_id: TypeId::new(),
         })
     }
 }

--- a/parser/src/types/enum_declaration.rs
+++ b/parser/src/types/enum_declaration.rs
@@ -28,7 +28,7 @@ impl ASTNode for EnumDeclaration {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let const_pos = reader
             .conditional_next(|tok| matches!(tok, TSXToken::Keyword(TSXKeyword::Const)))
@@ -62,7 +62,7 @@ impl ASTNode for EnumDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if self.is_constant {
@@ -112,7 +112,7 @@ impl ASTNode for EnumMember {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> Result<Self, crate::ParseError> {
         let (name, start_pos) = token_as_identifier(
             reader.next().ok_or_else(parse_lexing_error)?,
@@ -139,7 +139,7 @@ impl ASTNode for EnumMember {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -2,19 +2,19 @@ use std::borrow::Cow;
 
 use crate::{
     errors::parse_lexing_error,
-    expressions::ExpressionId,
     extensions::decorators::Decorated,
     parse_bracketed, to_string_bracketed,
     tokens::token_as_identifier,
     tsx_keywords,
-    types::{type_declarations::*, type_references::TypeReferenceFunctionParameters},
-    ASTNode, Block, Expression, GenericTypeConstraint, Keyword, NumberStructure, ParseError,
-    ParseErrors, ParseResult, ParseSettings, PropertyId, PropertyKey, Span, TSXKeyword, TSXToken,
-    TypeId, TypeReference,
+    types::{type_annotations::TypeAnnotationFunctionParameters, type_declarations::*},
+    ASTNode, Expression, GenericTypeConstraint, Keyword, NumberStructure, ParseError, ParseErrors,
+    ParseOptions, ParseResult, PropertyKey, Span, TSXKeyword, TSXToken, TypeAnnotation,
 };
 
 use iterator_endiate::EndiateIteratorExt;
 use tokenizer_lib::{Token, TokenReader};
+
+use super::AnnotationPerforms;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
@@ -25,10 +25,9 @@ pub struct InterfaceDeclaration {
     pub name: String,
     #[cfg(feature = "extras")]
     pub nominal_keyword: Option<Keyword<tsx_keywords::Nominal>>,
-    pub type_id: TypeId,
     pub type_parameters: Option<Vec<GenericTypeConstraint>>,
     /// The document interface extends a multiple of other interfaces
-    pub extends: Option<Vec<TypeReference>>,
+    pub extends: Option<Vec<TypeAnnotation>>,
     pub members: Vec<Decorated<InterfaceMember>>,
     pub position: Span,
 }
@@ -60,7 +59,7 @@ impl ASTNode for InterfaceDeclaration {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let start = reader.expect_next(TSXToken::Keyword(TSXKeyword::Interface))?;
 
@@ -76,19 +75,21 @@ impl ASTNode for InterfaceDeclaration {
             type_parameters,
             ..
         } = TypeDeclaration::from_reader(reader, state, settings)?;
-        let extends = if let TSXToken::Keyword(TSXKeyword::Extends) = reader.peek().unwrap().0 {
+
+        let extends = if let Some(Token(TSXToken::Keyword(TSXKeyword::Extends), _)) = reader.peek()
+        {
             reader.next();
-            let type_reference = TypeReference::from_reader(reader, state, settings)?;
-            let mut extends = vec![type_reference];
-            if matches!(reader.peek().unwrap().0, TSXToken::Comma) {
+            let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+            let mut extends = vec![type_annotation];
+            if matches!(reader.peek(), Some(Token(TSXToken::Comma, _))) {
                 reader.next();
                 loop {
-                    extends.push(TypeReference::from_reader(reader, state, settings)?);
-                    match reader.peek().unwrap().0 {
-                        TSXToken::Comma => {
+                    extends.push(TypeAnnotation::from_reader(reader, state, settings)?);
+                    match reader.peek() {
+                        Some(Token(TSXToken::Comma, _)) => {
                             reader.next();
                         }
-                        TSXToken::OpenBrace => break,
+                        Some(Token(TSXToken::OpenBrace, _)) => break,
                         _ => unimplemented!(),
                     }
                 }
@@ -97,6 +98,7 @@ impl ASTNode for InterfaceDeclaration {
         } else {
             None
         };
+
         reader.expect_next(TSXToken::OpenBrace)?;
         let members = parse_interface_members(reader, state, settings)?;
         let position = start.union(&reader.expect_next(TSXToken::CloseBrace)?);
@@ -104,7 +106,6 @@ impl ASTNode for InterfaceDeclaration {
             nominal_keyword,
             name,
             members,
-            type_id: TypeId::new(),
             type_parameters,
             extends,
             position,
@@ -114,7 +115,7 @@ impl ASTNode for InterfaceDeclaration {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_types {
@@ -138,7 +139,7 @@ impl ASTNode for InterfaceDeclaration {
                 buf.push_new_line();
             }
             for member in self.members.iter() {
-                settings.add_indent(depth, buf);
+                settings.add_indent(depth + 1, buf);
                 member.to_string_from_buffer(buf, settings, depth + 1);
                 if settings.pretty {
                     buf.push_new_line();
@@ -153,61 +154,7 @@ impl ASTNode for InterfaceDeclaration {
     }
 }
 
-#[cfg(feature = "extras")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "self-rust-tokenize",
-    derive(self_rust_tokenize::SelfRustTokenize)
-)]
-pub struct InterfaceMemberBody {
-    pub performs_keyword: Keyword<tsx_keywords::Performs>,
-    pub condition: Option<Box<crate::Expression>>,
-    pub body: Block,
-}
-
-#[cfg(feature = "extras")]
-impl ASTNode for InterfaceMemberBody {
-    fn get_position(&self) -> Cow<Span> {
-        todo!()
-    }
-
-    fn from_reader(
-        reader: &mut impl TokenReader<TSXToken, Span>,
-        state: &mut crate::ParsingState,
-        settings: &ParseSettings,
-    ) -> ParseResult<Self> {
-        let performs_keyword =
-            Keyword::new(reader.expect_next(TSXToken::Keyword(TSXKeyword::Performs))?);
-        let next_is_open_paren =
-            reader.conditional_next(|tok| matches!(tok, TSXToken::OpenParentheses));
-        let condition = if next_is_open_paren.is_some() {
-            let expression = Expression::from_reader(reader, state, settings)?;
-            reader.expect_next(TSXToken::CloseParentheses)?;
-            Some(Box::new(expression))
-        } else {
-            None
-        };
-
-        let body = Block::from_reader(reader, state, settings)?;
-
-        Ok(InterfaceMemberBody {
-            performs_keyword,
-            condition,
-            body,
-        })
-    }
-
-    fn to_string_from_buffer<T: source_map::ToString>(
-        &self,
-        _buf: &mut T,
-        _settings: &crate::ToStringSettings,
-        _depth: u8,
-    ) {
-        todo!()
-    }
-}
-
-/// This is also used for [TypeReference::ObjectLiteral]
+/// This is also used for [TypeAnnotation::ObjectLiteral]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
@@ -217,16 +164,16 @@ pub enum InterfaceMember {
     Method {
         name: PropertyKey,
         type_parameters: Option<Vec<GenericTypeConstraint>>,
-        parameters: TypeReferenceFunctionParameters,
-        return_type: Option<TypeReference>,
+        parameters: TypeAnnotationFunctionParameters,
+        return_type: Option<TypeAnnotation>,
         is_optional: bool,
         #[cfg(feature = "extras")]
-        body: Option<InterfaceMemberBody>,
+        performs: Option<AnnotationPerforms>,
         position: Span,
     },
     Property {
         name: PropertyKey,
-        type_reference: TypeReference,
+        type_annotation: TypeAnnotation,
         is_readonly: bool,
         /// Marked with `?:`
         is_optional: bool,
@@ -234,8 +181,8 @@ pub enum InterfaceMember {
     },
     Indexer {
         name: String,
-        indexer_type: TypeReference,
-        return_type: TypeReference,
+        indexer_type: TypeAnnotation,
+        return_type: TypeAnnotation,
         is_readonly: bool,
         position: Span,
     },
@@ -244,16 +191,16 @@ pub enum InterfaceMember {
     /// new (...params: any[]): HTMLElement
     /// ```
     Constructor {
-        parameters: TypeReferenceFunctionParameters,
+        parameters: TypeAnnotationFunctionParameters,
         type_parameters: Option<Vec<GenericTypeConstraint>>,
-        return_type: Option<TypeReference>,
+        return_type: Option<TypeAnnotation>,
         is_readonly: bool,
         position: Span,
     },
     Caller {
-        parameters: TypeReferenceFunctionParameters,
+        parameters: TypeAnnotationFunctionParameters,
         type_parameters: Option<Vec<GenericTypeConstraint>>,
-        return_type: Option<TypeReference>,
+        return_type: Option<TypeAnnotation>,
         is_readonly: bool,
         position: Span,
     },
@@ -261,10 +208,10 @@ pub enum InterfaceMember {
     Rule {
         parameter: String,
         rule: TypeRule,
-        matching_type: Box<TypeReference>,
+        matching_type: Box<TypeAnnotation>,
         optionality: Optionality,
         is_readonly: bool,
-        output_type: Box<TypeReference>,
+        output_type: Box<TypeAnnotation>,
         position: Span,
     },
     Comment(String),
@@ -274,7 +221,7 @@ impl ASTNode for InterfaceMember {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let readonly_pos = reader
             .conditional_next(|tok| matches!(tok, TSXToken::Keyword(TSXKeyword::Readonly)))
@@ -290,14 +237,12 @@ impl ASTNode for InterfaceMember {
                 let Token(_, start_pos) = reader.next().unwrap();
                 let (name, end_pos) = match reader.next().ok_or_else(parse_lexing_error)? {
                     Token(TSXToken::SingleQuotedStringLiteral(name), pos)
-                    | Token(TSXToken::DoubleQuotedStringLiteral(name), pos) => (
-                        PropertyKey::StringLiteral(name, PropertyId::new(), pos.clone()),
-                        pos,
-                    ),
+                    | Token(TSXToken::DoubleQuotedStringLiteral(name), pos) => {
+                        (PropertyKey::StringLiteral(name, pos.clone()), pos)
+                    }
                     Token(TSXToken::NumberLiteral(value), pos) => (
                         PropertyKey::NumberLiteral(
                             value.parse::<NumberStructure>().unwrap(),
-                            PropertyId::new(),
                             pos.clone(),
                         ),
                         pos,
@@ -308,8 +253,7 @@ impl ASTNode for InterfaceMember {
 
                         // Catch for computed symbol: e.g. `[Symbol.instanceOf()]`, rather than indexer
                         if let Some(Token(TSXToken::Dot, _)) = reader.peek() {
-                            let top =
-                                Expression::VariableReference(name, name_pos, ExpressionId::new());
+                            let top = Expression::VariableReference(name, name_pos);
                             // TODO bad
                             let expression = Expression::from_reader_sub_first_expression(
                                 reader, state, settings, 0, top,
@@ -318,7 +262,6 @@ impl ASTNode for InterfaceMember {
                             (
                                 PropertyKey::Computed(
                                     Box::new(expression),
-                                    PropertyId::new(),
                                     start_pos.union(&end_pos),
                                 ),
                                 end_pos,
@@ -328,11 +271,11 @@ impl ASTNode for InterfaceMember {
                                 // Indexed type
                                 Token(TSXToken::Colon, _) => {
                                     let indexer_type =
-                                        TypeReference::from_reader(reader, state, settings)?;
+                                        TypeAnnotation::from_reader(reader, state, settings)?;
                                     reader.expect_next(TSXToken::CloseBracket)?;
                                     reader.expect_next(TSXToken::Colon)?;
                                     let return_type =
-                                        TypeReference::from_reader(reader, state, settings)?;
+                                        TypeAnnotation::from_reader(reader, state, settings)?;
                                     return Ok(InterfaceMember::Indexer {
                                         name,
                                         indexer_type,
@@ -354,7 +297,7 @@ impl ASTNode for InterfaceMember {
                                         TypeRule::In
                                     };
                                     let matching_type =
-                                        TypeReference::from_reader(reader, state, settings)?;
+                                        TypeAnnotation::from_reader(reader, state, settings)?;
                                     reader.expect_next(TSXToken::CloseBracket)?;
                                     // TODO the -?: ?: : stuff '-?:' should be a token
                                     let token = reader.next().ok_or_else(parse_lexing_error)?;
@@ -379,7 +322,7 @@ impl ASTNode for InterfaceMember {
                                         }
                                     };
                                     let output_type =
-                                        TypeReference::from_reader(reader, state, settings)?;
+                                        TypeAnnotation::from_reader(reader, state, settings)?;
                                     let position = readonly_pos
                                         .unwrap_or(name_pos)
                                         .union(&output_type.get_position());
@@ -414,11 +357,11 @@ impl ASTNode for InterfaceMember {
             // Calling self
             TSXToken::OpenParentheses => {
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
                 // let parameters = function_parameters_from_reader(reader, state, settings)?;
                 let return_type = if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
                     reader.next();
-                    Some(TypeReference::from_reader(reader, state, settings)?)
+                    Some(TypeAnnotation::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
@@ -442,10 +385,10 @@ impl ASTNode for InterfaceMember {
                 let (type_parameters, start_pos) =
                     parse_bracketed(reader, state, settings, None, TSXToken::CloseChevron)?;
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
                 let return_type = if let Some(Token(TSXToken::Colon, _)) = reader.peek() {
                     reader.next();
-                    Some(TypeReference::from_reader(reader, state, settings)?)
+                    Some(TypeAnnotation::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
@@ -474,12 +417,12 @@ impl ASTNode for InterfaceMember {
                     None
                 };
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
                 let return_type = if reader
                     .conditional_next(|token| *token == TSXToken::Colon)
                     .is_some()
                 {
-                    Some(TypeReference::from_reader(reader, state, settings)?)
+                    Some(TypeAnnotation::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
@@ -513,7 +456,7 @@ impl ASTNode for InterfaceMember {
                 | TSXToken::DoubleQuotedStringLiteral(name) = token
                 {
                     (
-                        PropertyKey::StringLiteral(name, PropertyId::new(), position.clone()),
+                        PropertyKey::StringLiteral(name, position.clone()),
                         None,
                         position,
                     )
@@ -528,7 +471,7 @@ impl ASTNode for InterfaceMember {
                     position,
                 } = TypeDeclaration::from_reader(reader, state, settings)?;
                 (
-                    PropertyKey::Ident(name, PropertyId::new(), position.clone()),
+                    PropertyKey::Ident(name, position.clone()),
                     type_parameters,
                     position,
                 )
@@ -540,26 +483,27 @@ impl ASTNode for InterfaceMember {
         // TODO a little weird as only functions can have type parameters:
         match reader.next().ok_or_else(parse_lexing_error)? {
             Token(TSXToken::OpenParentheses, start_pos) => {
-                let parameters = TypeReferenceFunctionParameters::from_reader_sub_open_parenthesis(
-                    reader, state, settings, start_pos,
-                )?;
+                let parameters =
+                    TypeAnnotationFunctionParameters::from_reader_sub_open_parenthesis(
+                        reader, state, settings, start_pos,
+                    )?;
                 position = position.union(&parameters.position);
                 let return_type = if reader
                     .conditional_next(|tok| matches!(tok, TSXToken::Colon))
                     .is_some()
                 {
-                    let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                    position = position.union(&type_reference.get_position());
-                    Some(type_reference)
+                    let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                    position = position.union(&type_annotation.get_position());
+                    Some(type_annotation)
                 } else {
                     None
                 };
 
                 #[cfg(feature = "extras")]
-                let body = if let Some(Token(TSXToken::Keyword(TSXKeyword::Performs), _)) =
+                let performs = if let Some(Token(TSXToken::Keyword(TSXKeyword::Performs), _)) =
                     reader.peek()
                 {
-                    Some(InterfaceMemberBody::from_reader(reader, state, settings)?)
+                    Some(AnnotationPerforms::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
@@ -572,14 +516,14 @@ impl ASTNode for InterfaceMember {
                     is_optional: false,
                     position,
                     #[cfg(feature = "extras")]
-                    body,
+                    performs,
                 })
             }
             Token(TSXToken::QuestionMark, _) => {
                 // TODO this is a little weird, I don't think '?(' is a actual token and is
                 // only used here. Making '?(' a token may break ternary where first expr is a group
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
 
                 position = position.union(&parameters.position);
 
@@ -587,18 +531,18 @@ impl ASTNode for InterfaceMember {
                     .conditional_next(|tok| matches!(tok, TSXToken::Colon))
                     .is_some()
                 {
-                    let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                    position = position.union(&type_reference.get_position());
-                    Some(type_reference)
+                    let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                    position = position.union(&type_annotation.get_position());
+                    Some(type_annotation)
                 } else {
                     None
                 };
 
                 #[cfg(feature = "extras")]
-                let body = if let Some(Token(TSXToken::Keyword(TSXKeyword::Performs), _)) =
+                let performs = if let Some(Token(TSXToken::Keyword(TSXKeyword::Performs), _)) =
                     reader.peek()
                 {
-                    Some(InterfaceMemberBody::from_reader(reader, state, settings)?)
+                    Some(AnnotationPerforms::from_reader(reader, state, settings)?)
                 } else {
                     None
                 };
@@ -611,31 +555,31 @@ impl ASTNode for InterfaceMember {
                     position,
                     return_type,
                     #[cfg(feature = "extras")]
-                    body,
+                    performs,
                 })
             }
             Token(TSXToken::Colon, _) => {
-                let mut type_reference = TypeReference::from_reader(reader, state, settings)?;
+                let mut type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
                 if is_readonly {
                     // TODO positioning:
-                    position = position.union(&type_reference.get_position());
-                    type_reference =
-                        TypeReference::Readonly(Box::new(type_reference), position.clone());
+                    position = position.union(&type_annotation.get_position());
+                    type_annotation =
+                        TypeAnnotation::Readonly(Box::new(type_annotation), position.clone());
                 }
                 Ok(InterfaceMember::Property {
                     name,
                     position,
-                    type_reference,
+                    type_annotation,
                     is_optional: false,
                     is_readonly,
                 })
             }
             Token(TSXToken::OptionalMember, _) => {
-                let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                let position = position.union(&type_reference.get_position());
+                let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                let position = position.union(&type_annotation.get_position());
                 Ok(InterfaceMember::Property {
                     name,
-                    type_reference,
+                    type_annotation,
                     is_optional: true,
                     is_readonly,
                     position,
@@ -659,13 +603,13 @@ impl ASTNode for InterfaceMember {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
             Self::Property {
                 name,
-                type_reference,
+                type_annotation,
                 is_readonly,
                 ..
             } => {
@@ -675,7 +619,7 @@ impl ASTNode for InterfaceMember {
                 name.to_string_from_buffer(buf, settings, depth);
                 buf.push(':');
                 settings.add_gap(buf);
-                type_reference.to_string_from_buffer(buf, settings, depth);
+                type_annotation.to_string_from_buffer(buf, settings, depth);
             }
             Self::Method {
                 name,
@@ -738,7 +682,7 @@ impl ASTNode for InterfaceMember {
 pub(crate) fn parse_interface_members(
     reader: &mut impl TokenReader<TSXToken, Span>,
     state: &mut crate::ParsingState,
-    settings: &ParseSettings,
+    settings: &ParseOptions,
 ) -> ParseResult<Vec<Decorated<InterfaceMember>>> {
     let mut members = Vec::new();
     loop {

--- a/parser/src/types/mod.rs
+++ b/parser/src/types/mod.rs
@@ -3,48 +3,15 @@ pub mod enum_declaration;
 pub mod interface;
 pub mod namespace;
 pub mod type_alias;
+pub mod type_annotations;
 pub mod type_declarations;
-pub mod type_references;
+
+use std::borrow::Cow;
 
 pub use interface::InterfaceDeclaration;
+use source_map::Span;
 
-use std::sync::atomic::{AtomicU16, Ordering};
-
-use derive_debug_extras::DebugExtras;
-
-static TYPE_COUNTER: AtomicU16 = AtomicU16::new(1);
-
-/// A id of a syntax types
-#[derive(PartialEq, Eq, Clone, Copy, DebugExtras, Hash)]
-pub struct TypeId(u16);
-
-impl TypeId {
-    pub fn new() -> Self {
-        TypeId(TYPE_COUNTER.fetch_add(1, Ordering::SeqCst))
-    }
-
-    pub const fn new_from_id(id: u16) -> Self {
-        TypeId(id)
-    }
-
-    #[doc(hidden)]
-    pub fn unwrap_identifier(self) -> u16 {
-        self.0
-    }
-
-    pub const NULL: Self = Self(0);
-}
-
-// TODO not sure
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for TypeId {
-    fn append_to_token_stream(
-        &self,
-        token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-    ) {
-        token_stream.extend(self_rust_tokenize::quote!(TypeId::new()))
-    }
-}
+use crate::{tsx_keywords, ASTNode, Block, Keyword};
 
 // [See](https://www.typescriptlang.org/docs/handbook/2/classes.html#member-visibility)
 // #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,3 +30,65 @@ impl self_rust_tokenize::SelfRustTokenize for TypeId {
 // 		}
 // 	}
 // }
+
+#[cfg(feature = "extras")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "self-rust-tokenize",
+    derive(self_rust_tokenize::SelfRustTokenize)
+)]
+pub enum AnnotationPerforms {
+    PerformsStatements {
+        performs_keyword: Keyword<tsx_keywords::Performs>,
+        statements: Block,
+    },
+    PerformsConst {
+        performs_keyword: Keyword<tsx_keywords::Performs>,
+        identifier: String,
+    },
+}
+
+#[cfg(feature = "extras")]
+impl ASTNode for AnnotationPerforms {
+    fn get_position(&self) -> Cow<Span> {
+        todo!()
+    }
+
+    fn from_reader(
+        reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
+        state: &mut crate::ParsingState,
+        settings: &crate::ParseOptions,
+    ) -> crate::ParseResult<Self> {
+        let performs_keyword = Keyword::new(
+            reader.expect_next(crate::TSXToken::Keyword(crate::TSXKeyword::Performs))?,
+        );
+        if let Some(tokenizer_lib::Token(crate::TSXToken::OpenBrace, _)) = reader.peek() {
+            // let expression = Expression::from_reader(reader, state, settings)?;
+            // reader.expect_next(TSXToken::CloseParentheses)?;
+            // Some(Box::new(expression))
+
+            let body = Block::from_reader(reader, state, settings)?;
+            Ok(AnnotationPerforms::PerformsStatements {
+                performs_keyword,
+                statements: body,
+            })
+        } else {
+            reader.expect_next(crate::TSXToken::Keyword(crate::TSXKeyword::Const))?;
+            let (identifier, _) =
+                crate::tokens::token_as_identifier(reader.next().unwrap(), "performs const")?;
+            Ok(AnnotationPerforms::PerformsConst {
+                performs_keyword,
+                identifier,
+            })
+        }
+    }
+
+    fn to_string_from_buffer<T: source_map::ToString>(
+        &self,
+        _buf: &mut T,
+        _settings: &crate::ToStringOptions,
+        _depth: u8,
+    ) {
+        todo!()
+    }
+}

--- a/parser/src/types/namespace.rs
+++ b/parser/src/types/namespace.rs
@@ -11,7 +11,7 @@ impl crate::ASTNode for Namespace {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, source_map::Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> crate::ParseResult<Self> {
         reader.expect_next(crate::TSXToken::Keyword(crate::TSXKeyword::Namespace))?;
         let (namespace_name, _) = crate::tokens::token_as_identifier(
@@ -40,7 +40,7 @@ impl crate::ASTNode for Namespace {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         _buf: &mut T,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
         todo!()

--- a/parser/src/types/type_alias.rs
+++ b/parser/src/types/type_alias.rs
@@ -1,6 +1,6 @@
 use source_map::Span;
 
-use crate::{ASTNode, TSXToken, TypeDeclaration, TypeId, TypeReference};
+use crate::{ASTNode, TSXToken, TypeAnnotation, TypeDeclaration};
 
 /// e.g. `type NumberArray = Array<number>`
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,8 +10,7 @@ use crate::{ASTNode, TSXToken, TypeDeclaration, TypeId, TypeReference};
 )]
 pub struct TypeAlias {
     pub type_name: TypeDeclaration,
-    pub type_expression: TypeReference,
-    pub type_id: TypeId,
+    pub type_expression: TypeAnnotation,
     position: Span,
 }
 
@@ -23,17 +22,16 @@ impl ASTNode for TypeAlias {
     fn from_reader(
         reader: &mut impl tokenizer_lib::TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &crate::ParseSettings,
+        settings: &crate::ParseOptions,
     ) -> crate::ParseResult<Self> {
         let start = reader.expect_next(TSXToken::Keyword(crate::TSXKeyword::Type))?;
         let type_name = TypeDeclaration::from_reader(reader, state, settings)?;
         reader.expect_next(TSXToken::Assign)?;
-        let type_expression = TypeReference::from_reader(reader, state, settings)?;
+        let type_expression = TypeAnnotation::from_reader(reader, state, settings)?;
         let position = start.union(&type_expression.get_position());
         Ok(Self {
             type_name,
             type_expression,
-            type_id: TypeId::new(),
             position,
         })
     }
@@ -41,7 +39,7 @@ impl ASTNode for TypeAlias {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if settings.include_types {

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use crate::tsx_keywords::New;
 use crate::{
     errors::parse_lexing_error, expressions::TemplateLiteralPart,
-    extensions::decorators::Decorated, CursorId, Decorator, Keyword, ParseResult, TypeId,
-    VariableField, VariableFieldInTypeReference, WithComment,
+    extensions::decorators::Decorated, CursorId, Decorator, Keyword, ParseResult, VariableField,
+    VariableFieldInTypeAnnotation, WithComment,
 };
 use crate::{parse_bracketed, to_string_bracketed};
 use derive_partial_eq_extras::PartialEqExtras;
@@ -16,7 +16,7 @@ use super::{
 };
 
 use crate::{
-    tokens::token_as_identifier, ASTNode, NumberStructure, ParseError, ParseSettings, Span,
+    tokens::token_as_identifier, ASTNode, NumberStructure, ParseError, ParseOptions, Span,
     TSXKeyword, TSXToken, Token, TokenReader,
 };
 
@@ -29,17 +29,17 @@ use crate::{
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub enum TypeReference {
+pub enum TypeAnnotation {
     /// A name e.g. `IPost`
     Name(String, Span),
     /// A name e.g. `Intl.IPost`. TODO can there be more than 2 members
     NamespacedName(String, String, Span),
     /// A name with generics e.g. `Array<number>`
-    NameWithGenericArguments(String, Vec<TypeReference>, Span),
+    NameWithGenericArguments(String, Vec<TypeAnnotation>, Span),
     /// Union e.g. `number | string`
-    Union(Vec<TypeReference>),
+    Union(Vec<TypeAnnotation>),
     /// Intersection e.g. `c & d`
-    Intersection(Vec<TypeReference>),
+    Intersection(Vec<TypeAnnotation>),
     /// String literal e.g. `"foo"`
     StringLiteral(String, Span),
     /// Number literal e.g. `45`
@@ -47,38 +47,36 @@ pub enum TypeReference {
     /// Boolean literal e.g. `true`
     BooleanLiteral(bool, Span),
     /// Array literal e.g. `string[]`. This is syntactic sugar for `Array` with type arguments. **This is not the same
-    /// as a [TypeReference::TupleLiteral]**
-    ArrayLiteral(Box<TypeReference>, Span),
+    /// as a [TypeAnnotation::TupleLiteral]**
+    ArrayLiteral(Box<TypeAnnotation>, Span),
     /// Function literal e.g. `(x: string) => string`
     FunctionLiteral {
         type_parameters: Option<Vec<GenericTypeConstraint>>,
-        parameters: TypeReferenceFunctionParameters,
-        return_type: Box<TypeReference>,
-        /// TODO...
-        type_id: TypeId,
+        parameters: TypeAnnotationFunctionParameters,
+        return_type: Box<TypeAnnotation>,
     },
     /// Construction literal e.g. `new (x: string) => string`
     ConstructorLiteral {
         new_keyword: Keyword<New>,
         type_parameters: Option<Vec<GenericTypeConstraint>>,
-        parameters: TypeReferenceFunctionParameters,
-        return_type: Box<TypeReference>,
+        parameters: TypeAnnotationFunctionParameters,
+        return_type: Box<TypeAnnotation>,
     },
     /// Object literal e.g. `{ y: string }`
     /// Here [TypeId] refers to the type it declares
-    ObjectLiteral(Vec<Decorated<InterfaceMember>>, TypeId, Span),
+    ObjectLiteral(Vec<Decorated<InterfaceMember>>, Span),
     /// Tuple literal e.g. `[number, x: string]`
-    TupleLiteral(Vec<TupleElement>, TypeId, Span),
+    TupleLiteral(Vec<TupleElement>, Span),
     ///
-    TemplateLiteral(Vec<TemplateLiteralPart<TypeReference>>, Span),
+    TemplateLiteral(Vec<TemplateLiteralPart<TypeAnnotation>>, Span),
     /// Declares type as not assignable (still has interior mutability) e.g. `readonly number`
-    Readonly(Box<TypeReference>, Span),
+    Readonly(Box<TypeAnnotation>, Span),
     /// Declares type as being union type of all property types e.g. `T[K]`
-    Index(Box<TypeReference>, Box<TypeReference>, Span),
+    Index(Box<TypeAnnotation>, Box<TypeAnnotation>, Span),
     /// KeyOf
-    KeyOf(Box<TypeReference>, Span),
+    KeyOf(Box<TypeAnnotation>, Span),
     /// For operation precedence reasons
-    ParenthesizedReference(Box<TypeReference>, Span),
+    ParenthesizedReference(Box<TypeAnnotation>, Span),
     Conditional {
         condition: TypeCondition,
         resolve_true: TypeConditionResult,
@@ -87,7 +85,7 @@ pub enum TypeReference {
     },
     Decorated(Decorator, Box<Self>, Span),
     #[self_tokenize_field(0)]
-    Cursor(CursorId<TypeReference>, Span),
+    Cursor(CursorId<TypeAnnotation>, Span),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,15 +96,15 @@ pub enum TypeReference {
 pub enum TupleElement {
     NonSpread {
         name: Option<String>,
-        ty: TypeReference,
+        ty: TypeAnnotation,
     },
     Spread {
         name: Option<String>,
-        ty: TypeReference,
+        ty: TypeAnnotation,
     },
 }
 
-/// Condition in a [TypeReference::Conditional]
+/// Condition in a [TypeAnnotation::Conditional]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
@@ -114,13 +112,13 @@ pub enum TupleElement {
 )]
 pub enum TypeCondition {
     Extends {
-        r#type: Box<TypeReference>,
-        extends: Box<TypeReference>,
+        ty: Box<TypeAnnotation>,
+        extends: Box<TypeAnnotation>,
         position: Span,
     },
     Is {
-        r#type: Box<TypeReference>,
-        is: Box<TypeReference>,
+        ty: Box<TypeAnnotation>,
+        is: Box<TypeAnnotation>,
         position: Span,
     },
 }
@@ -129,19 +127,17 @@ impl TypeCondition {
     pub(crate) fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
-            TypeCondition::Extends {
-                r#type, extends, ..
-            } => {
-                r#type.to_string_from_buffer(buf, settings, depth);
+            TypeCondition::Extends { ty, extends, .. } => {
+                ty.to_string_from_buffer(buf, settings, depth);
                 buf.push_str(" extends ");
                 extends.to_string_from_buffer(buf, settings, depth);
             }
-            TypeCondition::Is { r#type, is, .. } => {
-                r#type.to_string_from_buffer(buf, settings, depth);
+            TypeCondition::Is { ty, is, .. } => {
+                ty.to_string_from_buffer(buf, settings, depth);
                 buf.push_str(" is ");
                 is.to_string_from_buffer(buf, settings, depth);
             }
@@ -157,7 +153,7 @@ impl TypeCondition {
     }
 }
 
-/// The result of a [TypeReference::Condition]
+/// The result of a [TypeAnnotation::Condition]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
@@ -165,8 +161,8 @@ impl TypeCondition {
 )]
 pub enum TypeConditionResult {
     /// TODO e.g. `infer number`
-    Infer(Box<TypeReference>, Span),
-    Reference(Box<TypeReference>),
+    Infer(Box<TypeAnnotation>, Span),
+    Reference(Box<TypeAnnotation>),
 }
 
 impl ASTNode for TypeConditionResult {
@@ -180,18 +176,18 @@ impl ASTNode for TypeConditionResult {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         if matches!(
             reader.peek().unwrap().0,
             TSXToken::Keyword(TSXKeyword::Infer)
         ) {
             let Token(_, start) = reader.next().unwrap();
-            let inferred_type = TypeReference::from_reader(reader, state, settings)?;
+            let inferred_type = TypeAnnotation::from_reader(reader, state, settings)?;
             let position = start.union(&inferred_type.get_position());
             Ok(Self::Infer(Box::new(inferred_type), position))
         } else {
-            TypeReference::from_reader(reader, state, settings)
+            TypeAnnotation::from_reader(reader, state, settings)
                 .map(|ty_ref| Self::Reference(Box::new(ty_ref)))
         }
     }
@@ -199,7 +195,7 @@ impl ASTNode for TypeConditionResult {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -214,11 +210,11 @@ impl ASTNode for TypeConditionResult {
     }
 }
 
-impl ASTNode for TypeReference {
+impl ASTNode for TypeAnnotation {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         Self::from_reader_with_config(reader, state, settings, false)
     }
@@ -226,7 +222,7 @@ impl ASTNode for TypeReference {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -235,10 +231,10 @@ impl ASTNode for TypeReference {
                     panic!()
                 }
             }
-            Self::Decorated(decorator, on_type_reference, _) => {
+            Self::Decorated(decorator, on_type_annotation, _) => {
                 decorator.to_string_from_buffer(buf, settings, depth);
                 buf.push(' ');
-                on_type_reference.to_string_from_buffer(buf, settings, depth)
+                on_type_annotation.to_string_from_buffer(buf, settings, depth)
             }
             Self::Name(name, _) => buf.push_str(name),
             Self::NameWithGenericArguments(name, arguments, _) => {
@@ -286,7 +282,7 @@ impl ASTNode for TypeReference {
                 }
             }
             Self::NamespacedName(..) => unimplemented!(),
-            Self::ObjectLiteral(members, _, _) => {
+            Self::ObjectLiteral(members, _) => {
                 buf.push('{');
                 for (at_end, member) in members.iter().endiate() {
                     member.to_string_from_buffer(buf, settings, depth);
@@ -296,7 +292,7 @@ impl ASTNode for TypeReference {
                 }
                 buf.push('}');
             }
-            Self::TupleLiteral(members, _, _) => {
+            Self::TupleLiteral(members, _) => {
                 buf.push('[');
                 for (at_end, member) in members.iter().endiate() {
                     match member {
@@ -388,8 +384,8 @@ impl ASTNode for TypeReference {
             | Self::NumberLiteral(_, position)
             | Self::Readonly(_, position)
             | Self::Conditional { position, .. }
-            | Self::ObjectLiteral(_, _, position)
-            | Self::TupleLiteral(_, _, position)
+            | Self::ObjectLiteral(_, position)
+            | Self::TupleLiteral(_, position)
             | Self::Index(_, _, position)
             | Self::KeyOf(_, position)
             | Self::ParenthesizedReference(_, position)
@@ -417,13 +413,13 @@ impl ASTNode for TypeReference {
     }
 }
 
-impl TypeReference {
+impl TypeAnnotation {
     /// Also returns the depth the generic arguments ran over
     /// TODO refactor and tidy a lot of this
     pub(crate) fn from_reader_with_config(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         return_on_union_or_intersection: bool,
     ) -> ParseResult<Self> {
         while let Some(Token(TSXToken::Comment(_) | TSXToken::MultiLineComment(_), _)) =
@@ -469,7 +465,7 @@ impl TypeReference {
                 // If arrow function OR group
                 if let Some(Token(TSXToken::Arrow, _)) = next {
                     let parameters =
-                        TypeReferenceFunctionParameters::from_reader_sub_open_parenthesis(
+                        TypeAnnotationFunctionParameters::from_reader_sub_open_parenthesis(
                             reader,
                             state,
                             settings,
@@ -480,27 +476,25 @@ impl TypeReference {
                     Self::FunctionLiteral {
                         type_parameters: None,
                         parameters,
-                        type_id: TypeId::new(),
                         return_type: Box::new(return_type),
                     }
                 } else {
-                    let type_reference = Self::from_reader(reader, state, settings)?;
+                    let type_annotation = Self::from_reader(reader, state, settings)?;
                     let end_position = reader.expect_next(TSXToken::CloseParentheses)?;
                     let position = start_position.union(&end_position);
-                    Self::ParenthesizedReference(type_reference.into(), position)
+                    Self::ParenthesizedReference(type_annotation.into(), position)
                 }
             }
             Token(TSXToken::OpenChevron, _start) => {
                 let (type_parameters, _) =
                     parse_bracketed(reader, state, settings, None, TSXToken::CloseChevron)?;
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
                 reader.expect_next(TSXToken::Arrow)?;
                 let return_type = Self::from_reader(reader, state, settings)?;
                 Self::FunctionLiteral {
                     type_parameters: Some(type_parameters),
                     parameters,
-                    type_id: TypeId::new(),
                     return_type: Box::new(return_type),
                 }
             }
@@ -508,7 +502,7 @@ impl TypeReference {
             Token(TSXToken::OpenBrace, start) => {
                 let members = parse_interface_members(reader, state, settings)?;
                 let position = start.union(&reader.expect_next(TSXToken::CloseBrace)?);
-                Self::ObjectLiteral(members, TypeId::new(), position)
+                Self::ObjectLiteral(members, position)
             }
             // Tuple literal type
             Token(TSXToken::OpenBracket, start_pos) => {
@@ -529,10 +523,10 @@ impl TypeReference {
                     };
                     let member = if let Some(Token(TSXToken::Spread, _)) = reader.peek() {
                         reader.next();
-                        let ty = TypeReference::from_reader(reader, state, settings)?;
+                        let ty = TypeAnnotation::from_reader(reader, state, settings)?;
                         TupleElement::Spread { name, ty }
                     } else {
-                        let ty = TypeReference::from_reader(reader, state, settings)?;
+                        let ty = TypeAnnotation::from_reader(reader, state, settings)?;
                         TupleElement::NonSpread { name, ty }
                     };
                     members.push(member);
@@ -543,7 +537,7 @@ impl TypeReference {
                     }
                 }
                 let end_pos = reader.expect_next(TSXToken::CloseBracket)?;
-                Self::TupleLiteral(members, TypeId::new(), start_pos.union(&end_pos))
+                Self::TupleLiteral(members, start_pos.union(&end_pos))
             }
             Token(TSXToken::TemplateLiteralStart, start) => {
                 let mut parts = Vec::new();
@@ -554,7 +548,7 @@ impl TypeReference {
                             parts.push(TemplateLiteralPart::Static(chunk));
                         }
                         Token(TSXToken::TemplateLiteralExpressionStart, _) => {
-                            let expression = TypeReference::from_reader(reader, state, settings)?;
+                            let expression = TypeAnnotation::from_reader(reader, state, settings)?;
                             reader.expect_next(TSXToken::TemplateLiteralExpressionEnd)?;
                             parts.push(TemplateLiteralPart::Dynamic(Box::new(expression)));
                         }
@@ -567,14 +561,14 @@ impl TypeReference {
                 Self::TemplateLiteral(parts, start.union(&end.unwrap()))
             }
             Token(TSXToken::Keyword(TSXKeyword::Readonly), start) => {
-                let readonly_type = TypeReference::from_reader(reader, state, settings)?;
+                let readonly_type = TypeAnnotation::from_reader(reader, state, settings)?;
                 let position = start.union(&readonly_type.get_position());
-                return Ok(TypeReference::Readonly(Box::new(readonly_type), position));
+                return Ok(TypeAnnotation::Readonly(Box::new(readonly_type), position));
             }
             Token(TSXToken::Keyword(TSXKeyword::KeyOf), start) => {
-                let key_of_type = TypeReference::from_reader(reader, state, settings)?;
+                let key_of_type = TypeAnnotation::from_reader(reader, state, settings)?;
                 let position = start.union(&key_of_type.get_position());
-                return Ok(TypeReference::KeyOf(Box::new(key_of_type), position));
+                return Ok(TypeAnnotation::KeyOf(Box::new(key_of_type), position));
             }
             Token(TSXToken::Keyword(TSXKeyword::New), span) => {
                 let type_parameters = reader
@@ -586,7 +580,7 @@ impl TypeReference {
                     })
                     .transpose()?;
                 let parameters =
-                    TypeReferenceFunctionParameters::from_reader(reader, state, settings)?;
+                    TypeAnnotationFunctionParameters::from_reader(reader, state, settings)?;
 
                 reader.expect_next(TSXToken::Arrow)?;
                 let return_type = Self::from_reader(reader, state, settings)?;
@@ -613,7 +607,7 @@ impl TypeReference {
             let (namespace_member, end) =
                 token_as_identifier(reader.next().unwrap(), "namespace name")?;
             let position = start.union(&end);
-            return Ok(TypeReference::NamespacedName(
+            return Ok(TypeAnnotation::NamespacedName(
                 name,
                 namespace_member,
                 position,
@@ -659,7 +653,7 @@ impl TypeReference {
                 reference = Self::ArrayLiteral(Box::new(reference), position);
             } else {
                 // E.g type allTypes = Person[keyof Person];
-                let indexer = TypeReference::from_reader(reader, state, settings)?;
+                let indexer = TypeAnnotation::from_reader(reader, state, settings)?;
                 let position = start.union(&reader.expect_next(TSXToken::CloseBracket)?);
                 reference = Self::Index(Box::new(reference), Box::new(indexer), position);
             }
@@ -670,11 +664,11 @@ impl TypeReference {
             Some(Token(TSXToken::Keyword(TSXKeyword::Extends), _)) => {
                 reader.next();
                 let extends_type =
-                    TypeReference::from_reader_with_config(reader, state, settings, true)?;
+                    TypeAnnotation::from_reader_with_config(reader, state, settings, true)?;
                 // TODO depth
                 let position = reference.get_position().union(&extends_type.get_position());
                 let condition = TypeCondition::Extends {
-                    r#type: Box::new(reference),
+                    ty: Box::new(reference),
                     extends: Box::new(extends_type),
                     position,
                 };
@@ -688,7 +682,7 @@ impl TypeReference {
                 let rhs = TypeConditionResult::from_reader(reader, state, settings)?;
                 let position = condition.get_position().union(&rhs.get_position());
                 // TODO zero here ..?
-                Ok(TypeReference::Conditional {
+                Ok(TypeAnnotation::Conditional {
                     condition,
                     resolve_true: lhs,
                     resolve_false: rhs,
@@ -698,11 +692,11 @@ impl TypeReference {
             Some(Token(TSXToken::Keyword(TSXKeyword::Is), _)) => {
                 reader.next();
                 let is_type =
-                    TypeReference::from_reader_with_config(reader, state, settings, true)?;
+                    TypeAnnotation::from_reader_with_config(reader, state, settings, true)?;
                 // TODO depth
                 let position = reference.get_position().union(&is_type.get_position());
                 let condition = TypeCondition::Is {
-                    r#type: Box::new(reference),
+                    ty: Box::new(reference),
                     is: Box::new(is_type),
                     position,
                 };
@@ -717,7 +711,7 @@ impl TypeReference {
                 let position = condition
                     .get_position()
                     .union(&resolve_false.get_position());
-                Ok(TypeReference::Conditional {
+                Ok(TypeAnnotation::Conditional {
                     condition,
                     resolve_true,
                     resolve_false,
@@ -756,18 +750,17 @@ impl TypeReference {
                 let position = reference.get_position().into_owned();
                 let function = Self::FunctionLiteral {
                     type_parameters: None,
-                    parameters: TypeReferenceFunctionParameters {
-                        parameters: vec![TypeReferenceFunctionParameter {
+                    parameters: TypeAnnotationFunctionParameters {
+                        parameters: vec![TypeAnnotationFunctionParameter {
                             name: None,
-                            type_reference: reference,
+                            type_annotation: reference,
+                            is_optional: false,
                             decorators: Default::default(),
                         }],
-                        optional_parameters: Default::default(),
                         rest_parameter: None,
                         position,
                     },
                     return_type: Box::new(return_type),
-                    type_id: TypeId::new(),
                 };
                 Ok(function)
             }
@@ -776,19 +769,19 @@ impl TypeReference {
     }
 }
 
-/// Parses the arguments (vector of [TypeReference]s) parsed to to a type reference or function call.
+/// Parses the arguments (vector of [TypeAnnotation]s) parsed to to a type reference or function call.
 /// Returns arguments and the closing span.
 /// TODO could use parse bracketed but needs to have the more complex logic inside
 pub(crate) fn generic_arguments_from_reader_sub_open_angle(
     reader: &mut impl TokenReader<TSXToken, Span>,
     state: &mut crate::ParsingState,
-    settings: &ParseSettings,
+    settings: &ParseOptions,
     return_on_union_or_intersection: bool,
-) -> ParseResult<(Vec<TypeReference>, Span)> {
+) -> ParseResult<(Vec<TypeAnnotation>, Span)> {
     let mut generic_arguments = Vec::new();
 
     loop {
-        let argument = TypeReference::from_reader_with_config(
+        let argument = TypeAnnotation::from_reader_with_config(
             reader,
             state,
             settings,
@@ -806,7 +799,7 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
             let close_chevron_span = Span {
                 start: span.start,
                 end: span.start + 1,
-                source_id: span.source_id,
+                source: span.source,
             };
             // Snipped
             span.start += 1;
@@ -818,7 +811,7 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
             let close_chevron_span = Span {
                 start: span.start,
                 end: span.start + 1,
-                source_id: span.source_id,
+                source: span.source,
             };
             // Snipped
             span.start += 1;
@@ -848,14 +841,13 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub struct TypeReferenceFunctionParameters {
-    pub parameters: Vec<TypeReferenceFunctionParameter>,
-    pub optional_parameters: Vec<TypeReferenceFunctionParameter>,
-    pub rest_parameter: Option<Box<TypeReferenceSpreadFunctionParameter>>,
+pub struct TypeAnnotationFunctionParameters {
+    pub parameters: Vec<TypeAnnotationFunctionParameter>,
+    pub rest_parameter: Option<Box<TypeAnnotationSpreadFunctionParameter>>,
     pub position: Span,
 }
 
-impl ASTNode for TypeReferenceFunctionParameters {
+impl ASTNode for TypeAnnotationFunctionParameters {
     fn get_position(&self) -> Cow<Span> {
         Cow::Borrowed(&self.position)
     }
@@ -863,7 +855,7 @@ impl ASTNode for TypeReferenceFunctionParameters {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let span = reader.expect_next(TSXToken::OpenParentheses)?;
         Self::from_reader_sub_open_parenthesis(reader, state, settings, span)
@@ -872,52 +864,43 @@ impl ASTNode for TypeReferenceFunctionParameters {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         for parameter in self.parameters.iter() {
             if let Some(ref name) = parameter.name {
                 name.to_string_from_buffer(buf, settings, depth);
             }
-            buf.push_str(": ");
-            parameter
-                .type_reference
-                .to_string_from_buffer(buf, settings, depth);
-        }
-        for parameter in self.optional_parameters.iter() {
-            if let Some(ref name) = parameter.name {
-                name.to_string_from_buffer(buf, settings, depth);
+            if parameter.is_optional {
+                buf.push_str("?: ");
+            } else {
+                buf.push_str(": ");
             }
-            buf.push_str("?: ");
             parameter
-                .type_reference
+                .type_annotation
                 .to_string_from_buffer(buf, settings, depth);
         }
         if let Some(ref rest_parameter) = self.rest_parameter {
             buf.push_str("...");
             buf.push_str(&rest_parameter.name);
             rest_parameter
-                .type_reference
+                .type_annotation
                 .to_string_from_buffer(buf, settings, depth);
         }
     }
 }
 
-impl TypeReferenceFunctionParameters {
+impl TypeAnnotationFunctionParameters {
     pub(crate) fn from_reader_sub_open_parenthesis(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
         open_paren_span: Span,
     ) -> ParseResult<Self> {
         let mut parameters = Vec::new();
-        let mut optional_parameters = Vec::new();
         let mut rest_parameter = None;
         while !matches!(reader.peek(), Some(Token(TSXToken::CloseParentheses, _))) {
-            while reader
-                .peek()
-                .map_or(false, |Token(r#type, _)| r#type.is_comment())
-            {
+            while reader.peek().map_or(false, |Token(ty, _)| ty.is_comment()) {
                 reader.next();
             }
             let mut decorators = Vec::<Decorator>::new();
@@ -931,11 +914,11 @@ impl TypeReferenceFunctionParameters {
                     "spread function parameter",
                 )?;
                 reader.expect_next(TSXToken::Colon)?;
-                let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                rest_parameter = Some(Box::new(TypeReferenceSpreadFunctionParameter {
+                let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                rest_parameter = Some(Box::new(TypeAnnotationSpreadFunctionParameter {
                     spread_position: span,
                     name,
-                    type_reference,
+                    type_annotation,
                     decorators,
                 }));
                 break;
@@ -952,7 +935,7 @@ impl TypeReferenceFunctionParameters {
                     }
                     _ => depth == 0,
                 });
-                let name: Option<WithComment<VariableField<VariableFieldInTypeReference>>> =
+                let name: Option<WithComment<VariableField<VariableFieldInTypeAnnotation>>> =
                     if let Some(Token(TSXToken::Colon | TSXToken::OptionalMember, _)) =
                         after_variable_field
                     {
@@ -973,17 +956,13 @@ impl TypeReferenceFunctionParameters {
                         ));
                     }
                 };
-                let type_reference = TypeReference::from_reader(reader, state, settings)?;
-                let parameter = TypeReferenceFunctionParameter {
+                let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+                parameters.push(TypeAnnotationFunctionParameter {
                     decorators,
                     name,
-                    type_reference,
-                };
-                if is_optional {
-                    optional_parameters.push(parameter);
-                } else {
-                    parameters.push(parameter);
-                }
+                    type_annotation,
+                    is_optional,
+                });
             }
 
             if reader
@@ -994,10 +973,9 @@ impl TypeReferenceFunctionParameters {
             }
         }
         let end_span = reader.expect_next(TSXToken::CloseParentheses)?;
-        Ok(TypeReferenceFunctionParameters {
+        Ok(TypeAnnotationFunctionParameters {
             position: open_paren_span.union(&end_span),
             parameters,
-            optional_parameters,
             rest_parameter,
         })
     }
@@ -1008,23 +986,24 @@ impl TypeReferenceFunctionParameters {
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub struct TypeReferenceFunctionParameter {
+pub struct TypeAnnotationFunctionParameter {
     pub decorators: Vec<Decorator>,
     /// Ooh nice optional
-    pub name: Option<WithComment<VariableField<VariableFieldInTypeReference>>>,
-    pub type_reference: TypeReference,
+    pub name: Option<WithComment<VariableField<VariableFieldInTypeAnnotation>>>,
+    pub type_annotation: TypeAnnotation,
+    pub is_optional: bool,
 }
 
-impl TypeReferenceFunctionParameter {
+impl TypeAnnotationFunctionParameter {
     // TODO decorators
     pub fn get_position(&self) -> Cow<Span> {
         if let Some(ref name) = self.name {
             Cow::Owned(
                 name.get_position()
-                    .union(&self.type_reference.get_position()),
+                    .union(&self.type_annotation.get_position()),
             )
         } else {
-            self.type_reference.get_position()
+            self.type_annotation.get_position()
         }
     }
 }
@@ -1034,11 +1013,11 @@ impl TypeReferenceFunctionParameter {
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub struct TypeReferenceSpreadFunctionParameter {
+pub struct TypeAnnotationSpreadFunctionParameter {
     pub decorators: Vec<Decorator>,
     pub spread_position: Span,
     pub name: String,
-    pub type_reference: TypeReference,
+    pub type_annotation: TypeAnnotation,
 }
 
 #[cfg(test)]
@@ -1048,50 +1027,53 @@ mod tests {
 
     #[test]
     fn name() {
-        assert_matches_ast!("string", TypeReference::Name(Deref @ "string", span!(0, 6)))
+        assert_matches_ast!(
+            "string",
+            TypeAnnotation::Name(Deref @ "string", span!(0, 6))
+        )
     }
 
     #[test]
     fn literals() {
         assert_matches_ast!(
             "\"string\"",
-            TypeReference::StringLiteral(Deref @ "string", span!(0, 8))
+            TypeAnnotation::StringLiteral(Deref @ "string", span!(0, 8))
         );
         assert_matches_ast!(
             "45",
-            TypeReference::NumberLiteral(NumberStructure::Number(_), span!(0, 2))
+            TypeAnnotation::NumberLiteral(NumberStructure::Number(_), span!(0, 2))
         );
-        assert_matches_ast!("true", TypeReference::BooleanLiteral(true, span!(0, 4)));
+        assert_matches_ast!("true", TypeAnnotation::BooleanLiteral(true, span!(0, 4)));
     }
 
     #[test]
     fn generics() {
         assert_matches_ast!(
             "Array<string>",
-            TypeReference::NameWithGenericArguments(
+            TypeAnnotation::NameWithGenericArguments(
                 Deref @ "Array",
-                Deref @ [TypeReference::Name(Deref @ "string", span!(6, 12))],
+                Deref @ [TypeAnnotation::Name(Deref @ "string", span!(6, 12))],
                 span!(0, 13),
             )
         );
 
         assert_matches_ast!(
             "Map<string, number>",
-            TypeReference::NameWithGenericArguments(
+            TypeAnnotation::NameWithGenericArguments(
                 Deref @ "Map",
                 Deref @
-                [TypeReference::Name(Deref @ "string", span!(4, 10)), TypeReference::Name(Deref @ "number", span!(12, 18))],
+                [TypeAnnotation::Name(Deref @ "string", span!(4, 10)), TypeAnnotation::Name(Deref @ "number", span!(12, 18))],
                 span!(0, 19),
             )
         );
 
         assert_matches_ast!(
             "Array<Array<string>>",
-            TypeReference::NameWithGenericArguments(
+            TypeAnnotation::NameWithGenericArguments(
                 Deref @ "Array",
-                Deref @ [TypeReference::NameWithGenericArguments(
+                Deref @ [TypeAnnotation::NameWithGenericArguments(
                     Deref @ "Array",
-                    Deref @ [TypeReference::Name(Deref @ "string", span!(12, 18))],
+                    Deref @ [TypeAnnotation::Name(Deref @ "string", span!(12, 18))],
                     span!(6, 19),
                 )],
                 span!(0, 20),
@@ -1103,9 +1085,9 @@ mod tests {
     fn union() {
         assert_matches_ast!(
             "string | number",
-            TypeReference::Union(
+            TypeAnnotation::Union(
                 Deref @
-                [TypeReference::Name(Deref @ "string", span!(0, 6)), TypeReference::Name(Deref @ "number", span!(9, 15))],
+                [TypeAnnotation::Name(Deref @ "string", span!(0, 6)), TypeAnnotation::Name(Deref @ "number", span!(9, 15))],
             )
         )
     }
@@ -1114,9 +1096,9 @@ mod tests {
     fn intersection() {
         assert_matches_ast!(
             "string & number",
-            TypeReference::Intersection(
+            TypeAnnotation::Intersection(
                 Deref @
-                [TypeReference::Name(Deref @ "string", span!(0, 6)), TypeReference::Name(Deref @ "number", span!(9, 15))],
+                [TypeAnnotation::Name(Deref @ "string", span!(0, 6)), TypeAnnotation::Name(Deref @ "number", span!(9, 15))],
             )
         )
     }
@@ -1125,15 +1107,14 @@ mod tests {
     fn tuple_literal() {
         assert_matches_ast!(
             "[number, x: string]",
-            TypeReference::TupleLiteral(
+            TypeAnnotation::TupleLiteral(
                 Deref @ [TupleElement::NonSpread {
                     name: None,
-                    ty: TypeReference::Name(Deref @ "number", span!(1, 7)),
+                    ty: TypeAnnotation::Name(Deref @ "number", span!(1, 7)),
                 }, TupleElement::NonSpread {
                     name: Some(Deref @ "x"),
-                    ty: TypeReference::Name(Deref @ "string", span!(12, 18)),
+                    ty: TypeAnnotation::Name(Deref @ "string", span!(12, 18)),
                 }],
-                _,
                 span!(0, 19),
             )
         );
@@ -1143,13 +1124,13 @@ mod tests {
     fn functions() {
         assert_matches_ast!(
             "T => T",
-            TypeReference::FunctionLiteral {
+            TypeAnnotation::FunctionLiteral {
                 type_parameters: None,
-                parameters: TypeReferenceFunctionParameters {
-                    parameters: Deref @ [ TypeReferenceFunctionParameter { .. } ],
+                parameters: TypeAnnotationFunctionParameters {
+                    parameters: Deref @ [ TypeAnnotationFunctionParameter { .. } ],
                     ..
                 },
-                return_type: Deref @ TypeReference::Name(Deref @ "T", span!(5, 6)),
+                return_type: Deref @ TypeAnnotation::Name(Deref @ "T", span!(5, 6)),
                 ..
             }
         );
@@ -1160,10 +1141,10 @@ mod tests {
     fn template_literal() {
         assert_matches_ast!(
             "`test-${X}`",
-            TypeReference::TemplateLiteral(
+            TypeAnnotation::TemplateLiteral(
                 Deref
                 @ [TemplateLiteralPart::Static(Deref @ "test-"), TemplateLiteralPart::Dynamic(
-                    Deref @ TypeReference::Name(Deref @ "X", span!(8, 9)),
+                    Deref @ TypeAnnotation::Name(Deref @ "X", span!(8, 9)),
                 )],
                 _,
             )
@@ -1174,18 +1155,18 @@ mod tests {
     fn array_shorthand() {
         assert_matches_ast!(
             "string[]",
-            TypeReference::ArrayLiteral(
-                Deref @ TypeReference::Name(Deref @ "string", span!(0, 6)),
+            TypeAnnotation::ArrayLiteral(
+                Deref @ TypeAnnotation::Name(Deref @ "string", span!(0, 6)),
                 span!(0, 8),
             )
         );
         assert_matches_ast!(
             "(number | null)[]",
-            TypeReference::ArrayLiteral(
-                Deref @ TypeReference::ParenthesizedReference(
-                    Deref @ TypeReference::Union(
+            TypeAnnotation::ArrayLiteral(
+                Deref @ TypeAnnotation::ParenthesizedReference(
+                    Deref @ TypeAnnotation::Union(
                         Deref @
-                        [TypeReference::Name(Deref @ "number", span!(1, 7)), TypeReference::Name(Deref @ "null", span!(10, 14))],
+                        [TypeAnnotation::Name(Deref @ "number", span!(1, 7)), TypeAnnotation::Name(Deref @ "null", span!(10, 14))],
                     ),
                     span!(0, 15),
                 ),
@@ -1194,9 +1175,9 @@ mod tests {
         );
         assert_matches_ast!(
             "string[][]",
-            TypeReference::ArrayLiteral(
-                Deref @ TypeReference::ArrayLiteral(
-                    Deref @ TypeReference::Name(Deref @ "string", span!(0, 6)),
+            TypeAnnotation::ArrayLiteral(
+                Deref @ TypeAnnotation::ArrayLiteral(
+                    Deref @ TypeAnnotation::Name(Deref @ "string", span!(0, 6)),
                     span!(0, 8),
                 ),
                 span!(0, 10),

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -1,60 +1,19 @@
 /// Contains:
 /// - [VariableId] given to variable declaring items
 /// - [VariableField] for destructuring things and its nested derivatives + visiting behavior + tests for self
-use std::{
-    borrow::Cow,
-    fmt::Debug,
-    sync::atomic::{AtomicU16, Ordering},
-};
+use std::{borrow::Cow, fmt::Debug};
 
 use crate::{
     errors::parse_lexing_error, parse_bracketed, property_key::PropertyKey,
     tokens::token_as_identifier, ASTNode, CursorId, Expression, ImmutableVariableOrPropertyPart,
-    MutableVariablePart, ParseError, ParseErrors, ParseResult, ParseSettings, Span, TSXToken,
-    Token, VisitSettings, Visitable, WithComment,
+    MutableVariablePart, ParseError, ParseErrors, ParseOptions, ParseResult, Span, TSXToken, Token,
+    VisitSettings, Visitable, WithComment,
 };
 
-use derive_debug_extras::DebugExtras;
 use derive_partial_eq_extras::PartialEqExtras;
 use iterator_endiate::EndiateIteratorExt;
 use self_rust_tokenize::SelfRustTokenize;
 use tokenizer_lib::TokenReader;
-
-static VARIABLE_COUNTER: AtomicU16 = AtomicU16::new(1);
-
-/// Id given to AST that declares a variable
-#[derive(PartialEq, Eq, Clone, Copy, DebugExtras, Hash)]
-pub struct VariableId(u16);
-
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for VariableId {
-    fn append_to_token_stream(
-        &self,
-        token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-    ) {
-        token_stream.extend(self_rust_tokenize::quote!(VariableId::new()))
-    }
-}
-
-impl VariableId {
-    pub fn new() -> Self {
-        Self(VARIABLE_COUNTER.fetch_add(1, Ordering::SeqCst))
-    }
-
-    /// Only use if you know what you are not causing clashing
-    pub const fn new_from_id(id: u16) -> Self {
-        Self(id)
-    }
-
-    /// TODO temp
-    pub fn unwrap_counter(&self) -> u16 {
-        self.0
-    }
-
-    pub fn set_counter_bad(value: u16) {
-        VARIABLE_COUNTER.store(value, Ordering::SeqCst)
-    }
-}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(
@@ -62,7 +21,7 @@ impl VariableId {
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
 pub enum VariableIdentifier {
-    Standard(String, VariableId, Span),
+    Standard(String, Span),
     #[self_tokenize_field(0)]
     Cursor(CursorId<Self>),
 }
@@ -70,7 +29,7 @@ pub enum VariableIdentifier {
 impl ASTNode for VariableIdentifier {
     fn get_position(&self) -> Cow<Span> {
         match self {
-            VariableIdentifier::Standard(_, _, span) => Cow::Borrowed(span),
+            VariableIdentifier::Standard(_, span) => Cow::Borrowed(span),
             VariableIdentifier::Cursor(_) => todo!(),
         }
     }
@@ -78,21 +37,21 @@ impl ASTNode for VariableIdentifier {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         _state: &mut crate::ParsingState,
-        _settings: &ParseSettings,
+        _settings: &ParseOptions,
     ) -> ParseResult<Self> {
         let token = reader.next().ok_or_else(parse_lexing_error)?;
         Ok(if let Token(TSXToken::Cursor(id), _) = token {
             Self::Cursor(id.into_cursor())
         } else {
             let (ident, span) = token_as_identifier(token, "variable identifier")?;
-            Self::Standard(ident, VariableId::new(), span)
+            Self::Standard(ident, span)
         })
     }
 
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
         buf.push_str(self.as_str());
@@ -100,17 +59,11 @@ impl ASTNode for VariableIdentifier {
 }
 
 impl VariableIdentifier {
+    /// TODO temp
     pub fn as_str(&self) -> &str {
         match self {
-            VariableIdentifier::Standard(name, _, _) => name.as_str(),
+            VariableIdentifier::Standard(name, _) => name.as_str(),
             VariableIdentifier::Cursor(_) => "",
-        }
-    }
-
-    fn try_get_id(&self) -> Option<VariableId> {
-        match self {
-            VariableIdentifier::Standard(_, id, _) => Some(*id),
-            VariableIdentifier::Cursor(_) => None,
         }
     }
 }
@@ -118,7 +71,7 @@ impl VariableIdentifier {
 /// A variable declaration name, used in variable declarations and function parameters.
 /// See [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
 #[derive(Debug, Clone)]
-pub enum VariableField<T: VariableFieldTypes> {
+pub enum VariableField<T: VariableFieldKind> {
     /// `x`
     Name(VariableIdentifier),
     /// `[x, y, z]`
@@ -128,7 +81,7 @@ pub enum VariableField<T: VariableFieldTypes> {
 }
 
 #[cfg(feature = "self-rust-tokenize")]
-impl<T: VariableFieldTypes> self_rust_tokenize::SelfRustTokenize for VariableField<T>
+impl<T: VariableFieldKind> self_rust_tokenize::SelfRustTokenize for VariableField<T>
 where
     T::OptionalExpression: self_rust_tokenize::SelfRustTokenize,
 {
@@ -161,13 +114,13 @@ where
     }
 }
 
-impl<T: VariableFieldTypes> From<VariableIdentifier> for VariableField<T> {
+impl<T: VariableFieldKind> From<VariableIdentifier> for VariableField<T> {
     fn from(value: VariableIdentifier) -> Self {
         Self::Name(value)
     }
 }
 
-impl<T: VariableFieldTypes + PartialEq> PartialEq for VariableField<T> {
+impl<T: VariableFieldKind + PartialEq> PartialEq for VariableField<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Name(l0), Self::Name(r0)) => l0 == r0,
@@ -178,26 +131,26 @@ impl<T: VariableFieldTypes + PartialEq> PartialEq for VariableField<T> {
     }
 }
 
-impl<T: VariableFieldTypes> Eq for VariableField<T> {}
+impl<T: VariableFieldKind> Eq for VariableField<T> {}
 
 /// Variable field can be used in type annotations but cannot have a value
 ///
 /// TODO value assignment this is VariableOrFieldAccess thingy
 ///
 /// TODO could have get_optional_expression_as_option(&Self::OptionalExpression) -> Option<Expression>
-pub trait VariableFieldTypes: PartialEq + Eq + Debug + Clone + 'static {
+pub trait VariableFieldKind: PartialEq + Eq + Debug + Clone + 'static {
     type OptionalExpression: PartialEq + Eq + Debug + Clone + Sync + Send;
 
     fn optional_expression_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> Result<Self::OptionalExpression, ParseError>;
 
     fn optional_expression_to_string_from_buffer<T: source_map::ToString>(
         optional_expression: &Self::OptionalExpression,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     );
 
@@ -209,13 +162,13 @@ pub trait VariableFieldTypes: PartialEq + Eq + Debug + Clone + 'static {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableFieldInSourceCode;
 
-impl VariableFieldTypes for VariableFieldInSourceCode {
+impl VariableFieldKind for VariableFieldInSourceCode {
     type OptionalExpression = Option<Expression>;
 
     fn optional_expression_from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> Result<Self::OptionalExpression, ParseError> {
         Ok(
             if reader
@@ -232,7 +185,7 @@ impl VariableFieldTypes for VariableFieldInSourceCode {
     fn optional_expression_to_string_from_buffer<T: source_map::ToString>(
         optional_expression: &Self::OptionalExpression,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         if let Some(optional_expression) = optional_expression {
@@ -250,15 +203,15 @@ impl VariableFieldTypes for VariableFieldInSourceCode {
 
 /// For function type references
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VariableFieldInTypeReference;
+pub struct VariableFieldInTypeAnnotation;
 
-impl VariableFieldTypes for VariableFieldInTypeReference {
+impl VariableFieldKind for VariableFieldInTypeAnnotation {
     type OptionalExpression = ();
 
     fn optional_expression_from_reader(
         _reader: &mut impl TokenReader<TSXToken, Span>,
         _state: &mut crate::ParsingState,
-        _settings: &ParseSettings,
+        _settings: &ParseOptions,
     ) -> Result<Self::OptionalExpression, ParseError> {
         Ok(())
     }
@@ -266,7 +219,7 @@ impl VariableFieldTypes for VariableFieldInTypeReference {
     fn optional_expression_to_string_from_buffer<T: source_map::ToString>(
         _optional_expression: &Self::OptionalExpression,
         _buf: &mut T,
-        _settings: &crate::ToStringSettings,
+        _settings: &crate::ToStringOptions,
         _depth: u8,
     ) {
     }
@@ -278,11 +231,11 @@ impl VariableFieldTypes for VariableFieldInTypeReference {
     }
 }
 
-impl<U: VariableFieldTypes> ASTNode for VariableField<U> {
+impl<U: VariableFieldKind> ASTNode for VariableField<U> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         match reader.peek().ok_or_else(parse_lexing_error)?.0 {
             TSXToken::OpenBrace => {
@@ -306,7 +259,7 @@ impl<U: VariableFieldTypes> ASTNode for VariableField<U> {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -348,23 +301,13 @@ impl<U: VariableFieldTypes> ASTNode for VariableField<U> {
     }
 }
 
-impl<T: VariableFieldTypes> VariableField<T> {
-    pub fn try_get_id(&self) -> Option<VariableId> {
-        match self {
-            VariableField::Name(identifier) => identifier.try_get_id(),
-            VariableField::Array(_, _) => None,
-            VariableField::Object(_, _) => None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEqExtras)]
-#[partial_eq_ignore_types(Span, T::Id)]
+#[partial_eq_ignore_types(Span)]
 #[cfg_attr(
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub enum ObjectDestructuringField<T: VariableFieldTypes> {
+pub enum ObjectDestructuringField<T: VariableFieldKind> {
     /// `{ ...x }`
     Spread(Span, VariableIdentifier),
     /// `{ x }`
@@ -378,7 +321,7 @@ pub enum ObjectDestructuringField<T: VariableFieldTypes> {
     },
 }
 
-impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
+impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
     fn get_position(&self) -> Cow<Span> {
         match self {
             // TODO account for `...` tokens
@@ -399,7 +342,7 @@ impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         match reader.peek().ok_or_else(parse_lexing_error)? {
             Token(TSXToken::Spread, _) => {
@@ -429,7 +372,7 @@ impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
                         default_value,
                         position,
                     })
-                } else if let PropertyKey::Ident(name, _, key_pos) = key {
+                } else if let PropertyKey::Ident(name, key_pos) = key {
                     let default_value =
                         U::optional_expression_from_reader(reader, state, settings)?;
                     let position =
@@ -438,7 +381,7 @@ impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
                         } else {
                             key_pos
                         };
-                    let standard = VariableIdentifier::Standard(name, VariableId::new(), position);
+                    let standard = VariableIdentifier::Standard(name, position);
                     Ok(Self::Name(standard, default_value))
                 } else {
                     let Token(token, pos) = reader.next().unwrap();
@@ -457,7 +400,7 @@ impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -490,13 +433,13 @@ impl<U: VariableFieldTypes> ASTNode for ObjectDestructuringField<U> {
     feature = "self-rust-tokenize",
     derive(self_rust_tokenize::SelfRustTokenize)
 )]
-pub enum ArrayDestructuringField<T: VariableFieldTypes> {
+pub enum ArrayDestructuringField<T: VariableFieldKind> {
     Spread(Span, VariableIdentifier),
     Name(WithComment<VariableField<T>>, T::OptionalExpression),
     None,
 }
 
-impl<T: VariableFieldTypes + PartialEq> PartialEq for ArrayDestructuringField<T> {
+impl<T: VariableFieldKind + PartialEq> PartialEq for ArrayDestructuringField<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Spread(_, l0), Self::Spread(_, r0)) => l0 == r0,
@@ -506,9 +449,9 @@ impl<T: VariableFieldTypes + PartialEq> PartialEq for ArrayDestructuringField<T>
     }
 }
 
-impl<T: VariableFieldTypes> Eq for ArrayDestructuringField<T> {}
+impl<T: VariableFieldKind> Eq for ArrayDestructuringField<T> {}
 
-impl<U: VariableFieldTypes> ASTNode for ArrayDestructuringField<U> {
+impl<U: VariableFieldKind> ASTNode for ArrayDestructuringField<U> {
     fn get_position(&self) -> Cow<Span> {
         match self {
             ArrayDestructuringField::Spread(spread_pos, ident) => {
@@ -530,7 +473,7 @@ impl<U: VariableFieldTypes> ASTNode for ArrayDestructuringField<U> {
     fn from_reader(
         reader: &mut impl TokenReader<TSXToken, Span>,
         state: &mut crate::ParsingState,
-        settings: &ParseSettings,
+        settings: &ParseOptions,
     ) -> ParseResult<Self> {
         match reader.peek().ok_or_else(parse_lexing_error)?.0 {
             TSXToken::Spread => {
@@ -552,7 +495,7 @@ impl<U: VariableFieldTypes> ASTNode for ArrayDestructuringField<U> {
     fn to_string_from_buffer<T: source_map::ToString>(
         &self,
         buf: &mut T,
-        settings: &crate::ToStringSettings,
+        settings: &crate::ToStringOptions,
         depth: u8,
     ) {
         match self {
@@ -569,18 +512,6 @@ impl<U: VariableFieldTypes> ASTNode for ArrayDestructuringField<U> {
     }
 }
 
-impl<T: VariableFieldTypes> ArrayDestructuringField<T> {
-    pub fn try_get_id(&self) -> Option<VariableId> {
-        match self {
-            ArrayDestructuringField::Spread(_, id) => id.try_get_id(),
-            ArrayDestructuringField::Name(variable_field, _) => {
-                variable_field.get_ast().try_get_id()
-            }
-            ArrayDestructuringField::None => None,
-        }
-    }
-}
-
 /// For object literals and things with computable or literal keys
 impl Visitable for WithComment<VariableField<VariableFieldInSourceCode>> {
     fn visit<TData>(
@@ -593,9 +524,8 @@ impl Visitable for WithComment<VariableField<VariableFieldInSourceCode>> {
         // TODO map
         match self.get_ast() {
             VariableField::Name(id) => {
-                if let VariableIdentifier::Standard(name, variable_id, pos) = id {
-                    let item =
-                        ImmutableVariableOrPropertyPart::VariableFieldName(name, *variable_id, pos);
+                if let VariableIdentifier::Standard(name, pos) = id {
+                    let item = ImmutableVariableOrPropertyPart::VariableFieldName(name, pos);
                     visitors.visit_variable(&item, data, chain);
                 }
             }
@@ -651,9 +581,9 @@ impl Visitable for WithComment<VariableField<VariableFieldInSourceCode>> {
     ) {
         match self.get_ast_mut() {
             VariableField::Name(identifier) => {
-                if let VariableIdentifier::Standard(name, variable_id, _span) = identifier {
+                if let VariableIdentifier::Standard(name, _span) = identifier {
                     visitors.visit_variable_mut(
-                        &mut MutableVariablePart::VariableFieldName(name, *variable_id),
+                        &mut MutableVariablePart::VariableFieldName(name),
                         data,
                         chain,
                     );
@@ -716,7 +646,6 @@ mod tests {
             "x",
             VariableField::Name(VariableIdentifier::Standard(
                 Deref @ "x",
-                _,
                 Span {
                     start: 0, end: 1, ..
                 },
@@ -732,21 +661,18 @@ mod tests {
                 Deref @ [ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "x",
-                        _,
                         span!(1, 2),
                     ))),
                     None,
                 ), ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "y",
-                        _,
                         span!(4, 5),
                     ))),
                     None,
                 ), ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "z",
-                        _,
                         span!(7, 8),
                     ))),
                     None,
@@ -761,14 +687,12 @@ mod tests {
                 Deref @ [ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "x",
-                        _,
                         span!(1, 2),
                     ))),
                     None,
                 ), ArrayDestructuringField::None, ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "z",
-                        _,
                         span!(5, 6),
                     ))),
                     None,
@@ -784,13 +708,13 @@ mod tests {
             "{x, y, z}",
             VariableField::Object(
                 Deref @ [WithComment::None(ObjectDestructuringField::Name(
-                    VariableIdentifier::Standard(Deref @ "x", _, span!(1, 2)),
+                    VariableIdentifier::Standard(Deref @ "x", span!(1, 2)),
                     None,
                 )), WithComment::None(ObjectDestructuringField::Name(
-                    VariableIdentifier::Standard(Deref @ "y", _, span!(4, 5)),
+                    VariableIdentifier::Standard(Deref @ "y", span!(4, 5)),
                     None,
                 )), WithComment::None(ObjectDestructuringField::Name(
-                    VariableIdentifier::Standard(Deref @ "z", _, span!(7, 8)),
+                    VariableIdentifier::Standard(Deref @ "z", span!(7, 8)),
                     None,
                 ))],
                 span!(0, 9),
@@ -804,12 +728,8 @@ mod tests {
             "{ x = 2 }",
             VariableField::Object(
                 Deref @ [WithComment::None(ObjectDestructuringField::Name(
-                    VariableIdentifier::Standard(Deref @ "x", _, span!(2, 7)),
-                    Some(Expression::NumberLiteral(
-                        crate::NumberStructure::Number(_),
-                        span!(6, 7),
-                        _,
-                    )),
+                    VariableIdentifier::Standard(Deref @ "x", span!(2, 7)),
+                    Some(Expression::NumberLiteral(crate::NumberStructure::Number(_), span!(6, 7))),
                 ))],
                 span!(0, 9),
             )
@@ -824,13 +744,12 @@ mod tests {
                 Deref @ [ArrayDestructuringField::Name(
                     WithComment::None(VariableField::Name(VariableIdentifier::Standard(
                         Deref @ "x",
-                        _,
                         span!(1, 2),
                     ))),
                     None,
                 ), ArrayDestructuringField::Spread(
                     span!(4, 7),
-                    VariableIdentifier::Standard(Deref @ "y", _, span!(7, 8)),
+                    VariableIdentifier::Standard(Deref @ "y", span!(7, 8)),
                 )],
                 span!(0, 9),
             )

--- a/parser/src/visiting.rs
+++ b/parser/src/visiting.rs
@@ -1,8 +1,8 @@
 use source_map::SourceId;
 
 use crate::{
-    expressions::ExpressionId, ArrayDestructuringField, BlockId, Expression, JSXElement,
-    ObjectDestructuringField, PropertyKey, Statement, VariableId, WithComment,
+    ArrayDestructuringField, Expression, JSXElement, ObjectDestructuringField, PropertyKey,
+    Statement, WithComment,
 };
 
 pub use ast::*;
@@ -225,9 +225,7 @@ mod ast {
         std::path::Path,
         std::path::PathBuf,
         source_map::Span,
-        crate::expressions::ExpressionId,
-        crate::variable_fields::VariableId,
-        crate::TypeReference,
+        crate::TypeAnnotation,
         crate::NumberStructure,
         crate::operators::BinaryOperator,
         crate::operators::BinaryAssignmentOperator,
@@ -239,7 +237,6 @@ mod ast {
         crate::types::type_alias::TypeAlias,
         crate::types::declares::DeclareFunctionDeclaration,
         crate::types::declares::DeclareVariableDeclaration,
-        crate::PropertyId,
         crate::VariableIdentifier,
         crate::PropertyReference,
         crate::Quoted,
@@ -251,49 +248,15 @@ mod ast {
 mod structures {
     use std::borrow::Cow;
 
-    use crate::{property_key::PropertyId, VariableFieldInSourceCode};
+    use crate::VariableFieldInSourceCode;
 
     use super::*;
-    use derive_enum_from_into::EnumFrom;
     use source_map::Span;
     use temporary_annex::{Annex, Annexable};
 
-    /// Could borrow identifiers but most of them are smaller than a pointer so it doesn't matter =
-    ///
-    /// TODO work out all the use cases for this
-    /// Currently used for
     #[derive(Debug, Clone)]
     pub enum ChainVariable {
-        Block(BlockId),
-        UnderFunction(BlockId, VariableId),
-        UnderClassMethod(BlockId),
-        UnderClassConstructor(BlockId),
-        UnderObjectLiteralMethod,
-        UnderExpressionFunctionBlock(BlockId, ExpressionId),
-        UnderArrowFunction(Option<BlockId>),
-        UnderRhsOfOperation(ExpressionId),
-        UnderMatchArm(BlockId),
-        UnderModule(BlockId, SourceId),
-        SingleStatementOrExpression,
-    }
-
-    impl ChainVariable {
-        pub fn get_block_id(&self) -> BlockId {
-            match self {
-                ChainVariable::Block(block_id)
-                | ChainVariable::UnderFunction(block_id, _)
-                | ChainVariable::UnderClassMethod(block_id)
-                | ChainVariable::UnderClassConstructor(block_id)
-                | ChainVariable::UnderModule(block_id, _)
-                | ChainVariable::UnderArrowFunction(Some(block_id))
-                | ChainVariable::UnderExpressionFunctionBlock(block_id, _) => *block_id,
-                ChainVariable::UnderMatchArm(block_id) => *block_id,
-                ChainVariable::UnderArrowFunction(None)
-                | ChainVariable::SingleStatementOrExpression => panic!(),
-                ChainVariable::UnderObjectLiteralMethod => todo!(),
-                ChainVariable::UnderRhsOfOperation(_) => todo!(),
-            }
-        }
+        Module(SourceId),
     }
 
     /// The current location in the AST
@@ -324,51 +287,13 @@ mod structures {
             &self.0
         }
 
-        // Returns the variableId this chain may be under
-        pub fn last_variable_id(&self) -> Option<VariableId> {
-            self.0.iter().rev().find_map(|chain_variable| {
-                // | ChainVariable::UnderClassMethod(_, variable_id)
-                if let ChainVariable::UnderFunction(_, variable_id) = chain_variable {
-                    Some(*variable_id)
-                } else {
-                    None
-                }
-            })
-        }
-
-        pub fn last_function(&self) -> Option<(BlockId, VariableId)> {
-            self.0.iter().rev().find_map(|chain_variable| {
-                // | ChainVariable::UnderClassMethod(block_id, variable_id)
-                if let ChainVariable::UnderFunction(block_id, variable_id) = chain_variable {
-                    Some((*block_id, *variable_id))
-                } else {
-                    None
-                }
-            })
-        }
-
-        pub fn first_function(&self) -> Option<(BlockId, VariableId)> {
-            self.0.iter().find_map(|chain_variable| {
-                // | ChainVariable::UnderClassMethod(block_id, variable_id)
-                if let ChainVariable::UnderFunction(block_id, variable_id) = chain_variable {
-                    Some((*block_id, *variable_id))
-                } else {
-                    None
-                }
-            })
-        }
-
-        pub fn last_block_id(&self) -> BlockId {
-            // TODO this needs changing
-            self.0.last().unwrap().get_block_id()
-        }
-
         pub fn get_module(&self) -> SourceId {
-            if let ChainVariable::UnderModule(_, source_id) = self.0.first().unwrap() {
-                *source_id
-            } else {
-                panic!()
-            }
+            todo!()
+            // if let ChainVariable::UnderModule(_, source) = self.0.first().unwrap() {
+            // 	*source
+            // } else {
+            // 	panic!()
+            // }
         }
 
         // TODO get function root. Aka last thing before in top level scope or
@@ -393,102 +318,63 @@ mod structures {
     /// TODO these may go
     #[derive(Debug)]
     pub enum MutableVariablePart<'a> {
-        VariableFieldName(&'a mut String, VariableId),
+        VariableFieldName(&'a mut String),
         // TODO these should maybe only be the spread variables
         ArrayDestructuringMember(&'a mut ArrayDestructuringField<VariableFieldInSourceCode>),
         ObjectDestructuringMember(
             &'a mut WithComment<ObjectDestructuringField<VariableFieldInSourceCode>>,
         ),
         PropertyKey(&'a mut WithComment<PropertyKey>, PropertyKeyLocation),
-        ClassName(Option<&'a mut String>, VariableId),
-        FunctionName(&'a mut String, VariableId),
+        ClassName(Option<&'a mut String>),
+        FunctionName(&'a mut String),
     }
 
     /// TODO these may go
     #[derive(Debug)]
     pub enum ImmutableVariableOrPropertyPart<'a> {
         // TODO maybe WithComment on some of these
-        VariableFieldName(&'a str, VariableId, &'a Span),
+        VariableFieldName(&'a str, &'a Span),
         // TODO these should maybe only be the spread variables
         ArrayDestructuringMember(&'a ArrayDestructuringField<VariableFieldInSourceCode>),
         ObjectDestructuringMember(
             &'a WithComment<ObjectDestructuringField<VariableFieldInSourceCode>>,
         ),
-        ClassName(Option<&'a str>, VariableId, &'a Span),
-        FunctionName(&'a str, VariableId, &'a Span),
+        ClassName(Option<&'a str>, &'a Span),
+        FunctionName(&'a str, &'a Span),
         PropertyKey(&'a WithComment<PropertyKey>, PropertyKeyLocation),
     }
 
     #[derive(Debug, Clone, Copy)]
     pub enum PropertyKeyLocation {
-        Class(VariableId),
-        ObjectLiteral(ExpressionId),
-    }
-
-    #[derive(Debug, Clone, Copy, EnumFrom)]
-    pub enum VariableOrPropertyId {
-        VariableId(VariableId),
-        PropertyId(PropertyId),
+        Class,
+        ObjectLiteral,
     }
 
     impl<'a> ImmutableVariableOrPropertyPart<'a> {
-        pub fn get_variable_id(&self) -> VariableOrPropertyId {
-            match self {
-                ImmutableVariableOrPropertyPart::VariableFieldName(_, variable_id, _)
-                | ImmutableVariableOrPropertyPart::ClassName(_, variable_id, _)
-                | ImmutableVariableOrPropertyPart::FunctionName(_, variable_id, _) => {
-                    (*variable_id).into()
-                }
-                ImmutableVariableOrPropertyPart::ArrayDestructuringMember(
-                    array_destructuring_member,
-                ) => match array_destructuring_member {
-                    ArrayDestructuringField::Spread(_, _identifier) => {
-                        todo!()
-                    }
-                    ArrayDestructuringField::Name(..) => todo!(),
-                    ArrayDestructuringField::None => todo!(),
-                },
-                ImmutableVariableOrPropertyPart::ObjectDestructuringMember(
-                    object_destructuring_member,
-                ) => match object_destructuring_member.get_ast() {
-                    ObjectDestructuringField::Spread(_, _identifier) => {
-                        todo!()
-                    }
-                    ObjectDestructuringField::Name { .. } => todo!(),
-                    ObjectDestructuringField::Map { .. } => todo!(),
-                },
-                ImmutableVariableOrPropertyPart::PropertyKey(property_key, _) => {
-                    property_key.get_ast().get_property_id().into()
-                }
-            }
-        }
-
         pub fn get_name(&self) -> Option<&'a str> {
             match self {
-                ImmutableVariableOrPropertyPart::FunctionName(name, _, _)
-                | ImmutableVariableOrPropertyPart::VariableFieldName(name, _, _) => Some(name),
+                ImmutableVariableOrPropertyPart::FunctionName(name, _)
+                | ImmutableVariableOrPropertyPart::VariableFieldName(name, _) => Some(name),
                 ImmutableVariableOrPropertyPart::ArrayDestructuringMember(_)
                 | ImmutableVariableOrPropertyPart::ObjectDestructuringMember(_) => None,
-                ImmutableVariableOrPropertyPart::ClassName(name, _, _) => *name,
-                ImmutableVariableOrPropertyPart::PropertyKey(property, _) => match property
-                    .get_ast()
-                {
-                    PropertyKey::Ident(ident, _, _) | PropertyKey::StringLiteral(ident, _, _) => {
-                        Some(ident.as_str())
+                ImmutableVariableOrPropertyPart::ClassName(name, _) => *name,
+                ImmutableVariableOrPropertyPart::PropertyKey(property, _) => {
+                    match property.get_ast() {
+                        PropertyKey::Ident(ident, _) | PropertyKey::StringLiteral(ident, _) => {
+                            Some(ident.as_str())
+                        }
+                        PropertyKey::NumberLiteral(_, _) | PropertyKey::Computed(_, _) => None,
                     }
-                    PropertyKey::NumberLiteral(_, _, _) | PropertyKey::Computed(_, _, _) => None,
-                },
+                }
             }
         }
 
         pub fn get_position(&self) -> Cow<Span> {
             use crate::ASTNode;
             match self {
-                ImmutableVariableOrPropertyPart::FunctionName(_, _, pos)
-                | ImmutableVariableOrPropertyPart::ClassName(_, _, pos)
-                | ImmutableVariableOrPropertyPart::VariableFieldName(_, _, pos) => {
-                    Cow::Borrowed(pos)
-                }
+                ImmutableVariableOrPropertyPart::FunctionName(_, pos)
+                | ImmutableVariableOrPropertyPart::ClassName(_, pos)
+                | ImmutableVariableOrPropertyPart::VariableFieldName(_, pos) => Cow::Borrowed(pos),
                 ImmutableVariableOrPropertyPart::ArrayDestructuringMember(member) => {
                     member.get_position()
                 }

--- a/parser/tests/cursors.rs
+++ b/parser/tests/cursors.rs
@@ -1,6 +1,5 @@
 use decaf_parser::{
-    expressions::ExpressionId, ASTNode, CursorId, Expression, SourceId, Span, Statement,
-    StatementOrDeclaration,
+    ASTNode, CursorId, Expression, SourceId, Span, Statement, StatementOrDeclaration,
 };
 
 #[test]
@@ -55,11 +54,9 @@ fn cursor_at_property_access() {
             parent: Box::new(Expression::VariableReference(
                 "x".to_owned(),
                 Span::NULL_SPAN,
-                ExpressionId::NULL
             )),
             property: decaf_parser::PropertyReference::Cursor(CursorId(0, Default::default())),
             position: Span::NULL_SPAN,
-            expression_id: ExpressionId::NULL,
             is_optional: false
         }
     );

--- a/parser/tests/statements.rs
+++ b/parser/tests/statements.rs
@@ -1,4 +1,5 @@
-use decaf_parser::{ASTNode, Module, SourceId};
+use decaf_parser::{ASTNode, Module, SourceId, ToStringOptions};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn statements() {
@@ -26,6 +27,9 @@ try {
     doThing()
 } catch (e) {
     console.error(e)
+}
+interface X {
+    a: string
 }"#
     .trim_start();
 
@@ -38,7 +42,7 @@ try {
     )
     .unwrap();
 
-    let output = module.to_string(&Default::default());
+    let output = module.to_string(&ToStringOptions::typescript());
 
     assert_eq!(output, input);
 }

--- a/parser/tests/visiting.rs
+++ b/parser/tests/visiting.rs
@@ -1,7 +1,8 @@
 use decaf_parser::{
     statements::UnconditionalElseStatement, ASTNode, Expression, Module, SourceId, Span, Statement,
-    ToStringSettings, VisitSettings, VisitorMut, VisitorsMut,
+    ToStringOptions, VisitSettings, VisitorMut, VisitorsMut,
 };
+use pretty_assertions::assert_eq;
 
 #[test]
 fn visiting() {
@@ -32,9 +33,9 @@ fn visiting() {
     };
     module.visit_mut(&mut visitors, &mut (), &VisitSettings::default());
 
-    let output = module.to_string(&ToStringSettings::minified());
+    let output = module.to_string(&ToStringOptions::minified());
 
-    let expected = r#"const x="HELLO WORLD";function y(){if(condition){do_thing("HELLO WORLD"+" TEST")}else{console.log("ELSE!")}}"#;
+    let expected = r#"const x="HELLO WORLD";function y(){if(condition){do_thing("HELLO WORLD"+" TEST")}else console.log("ELSE!")}"#;
     assert_eq!(output, expected);
 }
 
@@ -43,7 +44,7 @@ struct MakeStringsUppercase;
 
 impl VisitorMut<Expression, ()> for MakeStringsUppercase {
     fn visit_mut(&mut self, item: &mut Expression, _data: &mut (), _chain: &decaf_parser::Chain) {
-        if let Expression::StringLiteral(content, _quoted, _, _) = item {
+        if let Expression::StringLiteral(content, _quoted, _) = item {
             *content = content.to_uppercase();
         }
     }

--- a/src/ast_explorer.rs
+++ b/src/ast_explorer.rs
@@ -4,7 +4,7 @@ use std::{fs, path::PathBuf};
 
 use argh::FromArgs;
 use enum_variants_strings::EnumVariantsStrings;
-use parser::{ASTNode, Expression, Module, SourceId, ToStringSettings};
+use parser::{ASTNode, Expression, Module, SourceId, ToStringOptions};
 
 use crate::{error_handling::emit_parser_error, utilities::print_to_cli};
 
@@ -135,9 +135,9 @@ impl ExplorerSubCommand {
                 match res {
                     Ok(module) => {
                         let settings = if matches!(self, ExplorerSubCommand::Prettifier(_)) {
-                            ToStringSettings::default()
+                            ToStringOptions::default()
                         } else {
-                            ToStringSettings::minified()
+                            ToStringOptions::minified()
                         };
                         print_to_cli(format_args!("{}", module.to_string(&settings)));
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -312,7 +312,7 @@ fn build<T: crate::FSResolver>(fs_resolver: T, build_arguments: BuildArguments) 
 
     // TODO debug_types temp
     // let type_check_settings = TypeCheckSettings { ..Default::default() };
-    let _output_settings = parser::ToStringSettings {
+    let _output_settings = parser::ToStringOptions {
         include_comments: !no_comments,
         pretty: !minify,
         ..Default::default()

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -27,7 +27,7 @@ pub(crate) fn emit_decaf_diagnostic(
     error: crate::error_handling::TempDiagnostic,
 ) -> Result<(), codespan_reporting::files::Error> {
     let reason = error.label;
-    let id = error.position.source_id;
+    let id = error.position.source;
     let range = std::ops::Range::from(error.position);
 
     let diagnostic = Diagnostic {

--- a/src/temp.rs
+++ b/src/temp.rs
@@ -1,9 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use parser::{
-    expressions::ExpressionId, source_map::MapFileStore, ASTNode, ParseSettings, SourceId,
-    ToStringSettings,
-};
+use parser::{source_map::MapFileStore, ASTNode, ParseOptions, SourceId, ToStringOptions};
 
 use crate::error_handling::{self, TempDiagnostic};
 
@@ -35,7 +32,7 @@ pub fn build<T: crate::FSResolver>(
 
     let module_result = parser::Module::from_string(
         content,
-        ParseSettings::default(),
+        ParseOptions::default(),
         source_id,
         None,
         Default::default(),
@@ -66,8 +63,7 @@ pub fn build<T: crate::FSResolver>(
         &parser::VisitSettings::default(),
     );
 
-    let (content, source_map) =
-        output.to_string_with_source_map(&ToStringSettings::minified(), &fs);
+    let (content, source_map) = output.to_string_with_source_map(&ToStringOptions::minified(), &fs);
 
     let output = Output {
         output_path: output_path.to_path_buf(),
@@ -116,8 +112,7 @@ impl parser::VisitorMut<parser::Expression, Vec<TempDiagnostic>> for InvertTerna
                     kind: error_handling::ErrorWarningInfo::Info,
                 });
 
-                let temp_swap =
-                    parser::Expression::Null(parser::Span::NULL_SPAN, ExpressionId::NULL);
+                let temp_swap = parser::Expression::Null(parser::Span::NULL_SPAN);
 
                 *condition = Box::new(std::mem::replace(operand, temp_swap));
                 std::mem::swap(truthy_result, falsy_result);


### PR DESCRIPTION
- Remove identifiers from Expression and TypeAnnotation (and elsewhere). Using position information suffices
- Other small fixes
  - More support for for loops
  - hex/binary/octal number parsing
  - Interface was missing as a keyword for a declaration
  - Missing items in From implementations
  - Renaming items